### PR TITLE
Unreal: decouple UIs to separate process

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "client/ayon_unreal/integration"]
+[submodule "integration"]
 	path = client/ayon_unreal/integration
 	url = https://github.com/ynput/ayon-unreal-plugin.git

--- a/client/ayon_unreal/addon.py
+++ b/client/ayon_unreal/addon.py
@@ -7,6 +7,14 @@ from .version import __version__
 UNREAL_ADDON_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
+def get_launch_script_path():
+    return os.path.join(
+        UNREAL_ADDON_ROOT,
+        "api",
+        "launch_script.py"
+    )
+
+
 class UnrealAddon(AYONAddon, IHostAddon):
     name = "unreal"
     version = __version__

--- a/client/ayon_unreal/api/__init__.py
+++ b/client/ayon_unreal/api/__init__.py
@@ -4,26 +4,24 @@
 from .plugin import (
     UnrealActorCreator,
     UnrealAssetCreator,
-    Loader
+    UnrealBaseLoader,
 )
 
 from .pipeline import (
     install,
     uninstall,
+    imprint,
     ls,
+    ls_inst,
     publish,
-    containerise,
     show_creator,
     show_loader,
     show_publisher,
     show_manager,
     show_experimental_tools,
-    show_tools_dialog,
-    show_tools_popup,
+    containerise,
     instantiate,
     UnrealHost,
-    set_sequence_hierarchy,
-    generate_sequence,
     maintained_selection
 )
 
@@ -33,19 +31,20 @@ __all__ = [
     "Loader",
     "install",
     "uninstall",
+    "UnrealActorCreator",
+    "UnrealAssetCreator",
+    "UnrealBaseLoader",
+    "imprint",
     "ls",
+    "ls_inst",
     "publish",
-    "containerise",
     "show_creator",
     "show_loader",
     "show_publisher",
     "show_manager",
     "show_experimental_tools",
-    "show_tools_dialog",
-    "show_tools_popup",
+    "containerise",
     "instantiate",
     "UnrealHost",
-    "set_sequence_hierarchy",
-    "generate_sequence",
     "maintained_selection"
 ]

--- a/client/ayon_unreal/api/communication_server.py
+++ b/client/ayon_unreal/api/communication_server.py
@@ -1,0 +1,714 @@
+import os
+import json
+import time
+import subprocess
+import collections
+import asyncio
+import logging
+import socket
+import threading
+from queue import Queue
+from contextlib import closing
+import aiohttp
+
+from aiohttp import web
+from aiohttp_json_rpc import JsonRpc
+from aiohttp_json_rpc.protocol import (
+    encode_request, encode_error, decode_msg, JsonRpcMsgTyp
+)
+from aiohttp_json_rpc.exceptions import RpcError
+
+from ayon_core.lib import emit_event
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+class CommunicationWrapper:
+    # TODO add logs and exceptions
+    communicator = None
+
+    log = logging.getLogger("CommunicationWrapper")
+
+    @classmethod
+    def create_qt_communicator(cls, *args, **kwargs):
+        """Create communicator for Artist usage."""
+        communicator = QtCommunicator(*args, **kwargs)
+        cls.set_communicator(communicator)
+        return communicator
+
+    @classmethod
+    def set_communicator(cls, communicator):
+        if not cls.communicator:
+            cls.communicator = communicator
+        else:
+            cls.log.warning("Communicator was set multiple times.")
+
+    @classmethod
+    def client(cls):
+        if not cls.communicator:
+            return None
+        return cls.communicator.client()
+
+    @classmethod
+    def execute_george(cls, george_script):
+        """Execute passed goerge script in TVPaint."""
+        if not cls.communicator:
+            return
+        return cls.communicator.execute_george(george_script)
+
+
+class WebSocketServer:
+    def __init__(self):
+        self.client = None
+
+        self.loop = asyncio.new_event_loop()
+        self.app = web.Application(loop=self.loop)
+        self.port = self.find_free_port()
+        self.websocket_thread = WebsocketServerThread(
+            self, self.port, loop=self.loop
+        )
+
+    @property
+    def server_is_running(self):
+        return self.websocket_thread.server_is_running
+
+    def add_route(self, *args, **kwargs):
+        self.app.router.add_route(*args, **kwargs)
+
+    @staticmethod
+    def find_free_port():
+        with closing(
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        ) as sock:
+            sock.bind(("", 0))
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            port = sock.getsockname()[1]
+        return port
+
+    def start(self):
+        self.websocket_thread.start()
+
+    def stop(self):
+        try:
+            if self.websocket_thread.is_running:
+                log.debug("Stopping websocket server")
+                self.websocket_thread.is_running = False
+                self.websocket_thread.stop()
+        except Exception:
+            log.warning(
+                "Error has happened during Killing websocket server",
+                exc_info=True
+            )
+
+
+class WebsocketServerThread(threading.Thread):
+    """ Listener for websocket rpc requests.
+
+        It would be probably better to "attach" this to main thread (as for
+        example Harmony needs to run something on main thread), but currently
+        it creates separate thread and separate asyncio event loop
+    """
+    def __init__(self, module, port, loop):
+        super(WebsocketServerThread, self).__init__()
+        self.is_running = False
+        self.server_is_running = False
+        self.port = port
+        self.module = module
+        self.loop = loop
+        self.runner = None
+        self.site = None
+        self.tasks = []
+
+    def run(self):
+        self.is_running = True
+
+        try:
+            log.debug("Starting websocket server")
+
+            self.loop.run_until_complete(self.start_server())
+
+            log.info(
+                "Running Websocket server on URL:"
+                " \"ws://localhost:{}\"".format(self.port)
+            )
+
+            asyncio.ensure_future(self.check_shutdown(), loop=self.loop)
+
+            self.server_is_running = True
+            self.loop.run_forever()
+
+        except Exception:
+            log.warning(
+                "Websocket Server service has failed", exc_info=True
+            )
+        finally:
+            self.server_is_running = False
+            # optional
+            self.loop.close()
+
+        self.is_running = False
+        log.info("Websocket server stopped")
+
+    async def start_server(self):
+        """ Starts runner and TCPsite """
+        self.runner = web.AppRunner(self.module.app)
+        await self.runner.setup()
+        self.site = web.TCPSite(self.runner, "localhost", self.port)
+        await self.site.start()
+
+    def stop(self):
+        """Sets is_running flag to false, 'check_shutdown' shuts server down"""
+        self.is_running = False
+
+    async def check_shutdown(self):
+        """ Future that is running and checks if server should be running
+            periodically.
+        """
+        while self.is_running:
+            while self.tasks:
+                task = self.tasks.pop(0)
+                log.debug("waiting for task {}".format(task))
+                await task
+                log.debug("returned value {}".format(task.result))
+
+            await asyncio.sleep(0.5)
+
+        log.debug("## Server shutdown started")
+
+        await self.site.stop()
+        log.debug("# Site stopped")
+        await self.runner.cleanup()
+        log.debug("# Server runner stopped")
+        tasks = [
+            task for task in asyncio.all_tasks()
+            if task is not asyncio.current_task()
+        ]
+        list(map(lambda task: task.cancel(), tasks))  # cancel all the tasks
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        log.debug(f"Finished awaiting cancelled tasks, results: {results}...")
+        await self.loop.shutdown_asyncgens()
+        # to really make sure everything else has time to stop
+        await asyncio.sleep(0.07)
+        self.loop.stop()
+
+
+class BaseUnrealRpc(JsonRpc):
+    def __init__(self, communication_obj, route_name="", **kwargs):
+        super().__init__(**kwargs)
+        self.requests_ids = collections.defaultdict(lambda: 0)
+        self.waiting_requests = collections.defaultdict(list)
+        self.responses = collections.defaultdict(list)
+
+        self.route_name = route_name
+        self.communication_obj = communication_obj
+
+    async def _handle_rpc_msg(self, http_request, raw_msg):
+        # This is duplicated code from super but there is no way how to do it
+        # to be able handle server->client requests
+        host = http_request.host
+        if host in self.waiting_requests:
+            try:
+                _raw_message = raw_msg.data
+                msg = decode_msg(_raw_message)
+
+            except RpcError as error:
+                await self._ws_send_str(http_request, encode_error(error))
+                return
+
+            if msg.type in (JsonRpcMsgTyp.RESULT, JsonRpcMsgTyp.ERROR):
+                msg_data = json.loads(_raw_message)
+                if msg_data.get("id") in self.waiting_requests[host]:
+                    self.responses[host].append(msg_data)
+                    return
+
+        return await super()._handle_rpc_msg(http_request, raw_msg)
+
+    def client_connected(self):
+        # TODO This is poor check. Add check it is client from TVPaint
+        if self.clients:
+            return True
+        return False
+
+    def send_notification(self, client, method, params=None):
+        if params is None:
+            params = []
+        asyncio.run_coroutine_threadsafe(
+            client.ws.send_str(encode_request(method, params=params)),
+            loop=self.loop
+        )
+
+    def send_request(self, client, method, params=None, timeout=0):
+        if params is None:
+            params = {}
+
+        client_host = client.host
+
+        request_id = self.requests_ids[client_host]
+        self.requests_ids[client_host] += 1
+
+        self.waiting_requests[client_host].append(request_id)
+
+        log.debug("Sending request to client {} ({}, {}) id: {}".format(
+            client_host, method, params, request_id
+        ))
+        future = asyncio.run_coroutine_threadsafe(
+            client.ws.send_str(encode_request(method, request_id, params)),
+            loop=self.loop
+        )
+        result = future.result()
+
+        not_found = object()
+        response = not_found
+        start = time.time()
+        while True:
+            if client.ws.closed:
+                return None
+
+            for _response in self.responses[client_host]:
+                _id = _response.get("id")
+                if _id == request_id:
+                    response = _response
+                    break
+
+            if response is not not_found:
+                break
+
+            if timeout > 0 and (time.time() - start) > timeout:
+                raise Exception("Timeout passed")
+                return
+
+            time.sleep(0.1)
+
+        if response is not_found:
+            raise Exception("Connection closed")
+
+        self.responses[client_host].remove(response)
+
+        error = response.get("error")
+        result = response.get("result")
+        if error:
+            raise Exception("Error happened: {}".format(error))
+        return result
+
+
+class QtUnrealRpc(BaseUnrealRpc):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        from openpype.tools.utils import host_tools
+        self.tools_helper = host_tools.HostToolsHelper()
+
+        route_name = self.route_name
+
+        # Register methods
+        self.add_methods(
+            (route_name, self.workfiles_tool),
+            (route_name, self.loader_tool),
+            (route_name, self.creator_tool),
+            (route_name, self.subset_manager_tool),
+            (route_name, self.publish_tool),
+            (route_name, self.scene_inventory_tool),
+            (route_name, self.library_loader_tool),
+            (route_name, self.experimental_tools)
+        )
+
+    # Panel routes for tools
+    async def workfiles_tool(self):
+        log.info("Triggering Workfile tool")
+        item = MainThreadItem(self.tools_helper.show_workfiles)
+        self._execute_in_main_thread(item)
+        return
+
+    async def loader_tool(self):
+        log.info("Triggering Loader tool")
+        item = MainThreadItem(self.tools_helper.show_loader)
+        self._execute_in_main_thread(item)
+        return
+
+    async def creator_tool(self):
+        log.info("Triggering Creator tool")
+        item = MainThreadItem(
+            self.tools_helper.show_publisher_tool, tab="create")
+        await self._async_execute_in_main_thread(item, wait=False)
+
+    async def subset_manager_tool(self):
+        log.info("Triggering Subset Manager tool")
+        item = MainThreadItem(self.tools_helper.show_subset_manager)
+        # Do not wait for result of callback
+        self._execute_in_main_thread(item, wait=False)
+        return
+
+    async def publish_tool(self):
+        log.info("Triggering Publish tool")
+        item = MainThreadItem(
+            self.tools_helper.show_publisher_tool, tab="publish")
+        self._execute_in_main_thread(item)
+        return
+
+    async def scene_inventory_tool(self):
+        """Open Scene Inventory tool.
+
+        Function can't confirm if tool was opened becauise one part of
+        SceneInventory initialization is calling websocket request to host but
+        host can't response because is waiting for response from this call.
+        """
+        log.info("Triggering Scene inventory tool")
+        item = MainThreadItem(self.tools_helper.show_scene_inventory)
+        # Do not wait for result of callback
+        self._execute_in_main_thread(item, wait=False)
+        return
+
+    async def library_loader_tool(self):
+        log.info("Triggering Library loader tool")
+        item = MainThreadItem(self.tools_helper.show_library_loader)
+        self._execute_in_main_thread(item)
+        return
+
+    async def experimental_tools(self):
+        log.info("Triggering Library loader tool")
+        item = MainThreadItem(self.tools_helper.show_experimental_tools_dialog)
+        self._execute_in_main_thread(item)
+        return
+
+    async def _async_execute_in_main_thread(self, item, **kwargs):
+        await self.communication_obj.async_execute_in_main_thread(
+            item, **kwargs
+        )
+
+    def _execute_in_main_thread(self, item, **kwargs):
+        return self.communication_obj.execute_in_main_thread(item, **kwargs)
+
+
+class MainThreadItem:
+    """Structure to store information about callback in main thread.
+
+    Item should be used to execute callback in main thread which may be needed
+    for execution of Qt objects.
+
+    Item store callback (callable variable), arguments and keyword arguments
+    for the callback. Item hold information about it's process.
+    """
+    not_set = object()
+    sleep_time = 0.1
+
+    def __init__(self, callback, *args, **kwargs):
+        self.done = False
+        self.exception = self.not_set
+        self.result = self.not_set
+        self.callback = callback
+        self.args = args
+        self.kwargs = kwargs
+
+    def execute(self):
+        """Execute callback and store it's result.
+
+        Method must be called from main thread. Item is marked as `done`
+        when callback execution finished. Store output of callback of exception
+        information when callback raise one.
+        """
+        log.debug("Executing process in main thread")
+        if self.done:
+            log.warning("- item is already processed")
+            return
+
+        callback = self.callback
+        args = self.args
+        kwargs = self.kwargs
+        log.info("Running callback: {}".format(str(callback)))
+        try:
+            result = callback(*args, **kwargs)
+            self.result = result
+
+        except Exception as exc:
+            self.exception = exc
+
+        finally:
+            self.done = True
+
+    def wait(self):
+        """Wait for result from main thread.
+
+        This method stops current thread until callback is executed.
+
+        Returns:
+            object: Output of callback. May be any type or object.
+
+        Raises:
+            Exception: Reraise any exception that happened during callback
+                execution.
+        """
+        while not self.done:
+            time.sleep(self.sleep_time)
+
+        if self.exception is self.not_set:
+            return self.result
+        raise self.exception
+
+    async def async_wait(self):
+        """Wait for result from main thread.
+
+        Returns:
+            object: Output of callback. May be any type or object.
+
+        Raises:
+            Exception: Reraise any exception that happened during callback
+                execution.
+        """
+        while not self.done:
+            await asyncio.sleep(self.sleep_time)
+
+        if self.exception is self.not_set:
+            return self.result
+        raise self.exception
+
+
+class BaseCommunicator:
+    def __init__(self):
+        self.process = None
+        self.websocket_server = None
+        self.websocket_rpc = None
+        self.exit_code = None
+        self._connected_client = None
+
+    @property
+    def server_is_running(self):
+        if self.websocket_server is None:
+            return False
+        return self.websocket_server.server_is_running
+
+    def _launch_unreal(self, launch_args):
+        flags = (
+            subprocess.DETACHED_PROCESS
+            | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+        env = os.environ.copy()
+
+        kwargs = {
+            "env": env,
+            "creationflags": flags
+        }
+        self.process = subprocess.Popen(launch_args, **kwargs)
+
+    def _create_routes(self):
+        self.websocket_rpc = BaseUnrealRpc(
+            self, loop=self.websocket_server.loop
+        )
+        self.websocket_server.add_route(
+            "*", "/ws", self.websocket_handler
+        )
+
+    async def websocket_handler(self, request):
+        print('Websocket connection starting')
+        ws = aiohttp.web.WebSocketResponse()
+        await ws.prepare(request)
+        print('Websocket connection ready')
+
+        async for msg in ws:
+            print(msg)
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                print(msg.data)
+                if msg.data == 'close':
+                    await ws.close()
+                else:
+                    await ws.send_str(msg.data + '/answer')
+
+        print('Websocket connection closed')
+        return ws
+
+    def _start_webserver(self):
+        self.websocket_server.start()
+        # Make sure RPC is using same loop as websocket server
+        while not self.websocket_server.server_is_running:
+            time.sleep(0.1)
+
+    def _stop_webserver(self):
+        self.websocket_server.stop()
+
+    def _exit(self, exit_code=None):
+        self._stop_webserver()
+        if exit_code is not None:
+            self.exit_code = exit_code
+
+        if self.exit_code is None:
+            self.exit_code = 0
+
+    def stop(self):
+        """Stop communication and currently running python process."""
+        log.info("Stopping communication")
+        self._exit()
+
+    def launch(self, launch_args):
+        """Prepare all required data and launch host.
+
+        First is prepared websocket server as communication point for host,
+        when server is ready to use host is launched as subprocess.
+        """
+        # if platform.system().lower() == "windows":
+        #     self._prepare_windows_plugin(launch_args)
+
+        # Launch TVPaint and the websocket server.
+        log.info("Launching Unreal")
+        self.websocket_server = WebSocketServer()
+
+        self._create_routes()
+
+        os.environ["WEBSOCKET_URL"] = "ws://localhost:{}/ws".format(
+            self.websocket_server.port
+        )
+
+        log.info("Added request handler for url: {}".format(
+            os.environ["WEBSOCKET_URL"]
+        ))
+
+        self._start_webserver()
+
+        # Start TVPaint when server is running
+        # self._launch_tv_paint(launch_args)
+        self._launch_unreal(launch_args)
+
+        log.info("Waiting for client connection")
+        while True:
+            if self.process.poll() is not None:
+                log.debug("Host process is not alive. Exiting")
+                self._exit(1)
+                return
+
+            if self.websocket_rpc.client_connected():
+                log.info("Client has connected")
+                break
+            time.sleep(0.5)
+
+        emit_event("application.launched")
+
+    def _client(self):
+        if not self.websocket_rpc:
+            log.warning("Communicator's server did not start yet.")
+            return None
+
+        for client in self.websocket_rpc.clients:
+            if not client.ws.closed:
+                return client
+        log.warning("Client is not yet connected to Communicator.")
+        return None
+
+    def client(self):
+        if not self._connected_client or self._connected_client.ws.closed:
+            self._connected_client = self._client()
+        return self._connected_client
+
+    def send_request(self, method, params=None):
+        client = self.client()
+        if not client:
+            return
+
+        return self.websocket_rpc.send_request(
+            client, method, params
+        )
+
+    def send_notification(self, method, params=None):
+        client = self.client()
+        if not client:
+            return
+
+        self.websocket_rpc.send_notification(
+            client, method, params
+        )
+
+
+class QtCommunicator(BaseCommunicator):
+    menu_definitions = {
+        "title": "OpenPype Tools",
+        "menu_items": [
+            {
+                "callback": "workfiles_tool",
+                "label": "Workfiles",
+                "help": "Open workfiles tool"
+            }, {
+                "callback": "loader_tool",
+                "label": "Load",
+                "help": "Open loader tool"
+            }, {
+                "callback": "creator_tool",
+                "label": "Create",
+                "help": "Open creator tool"
+            }, {
+                "callback": "scene_inventory_tool",
+                "label": "Scene inventory",
+                "help": "Open scene inventory tool"
+            }, {
+                "callback": "publish_tool",
+                "label": "Publish",
+                "help": "Open publisher"
+            }, {
+                "callback": "library_loader_tool",
+                "label": "Library",
+                "help": "Open library loader tool"
+            }, {
+                "callback": "subset_manager_tool",
+                "label": "Subset Manager",
+                "help": "Open subset manager tool"
+            }, {
+                "callback": "experimental_tools",
+                "label": "Experimental tools",
+                "help": "Open experimental tools dialog"
+            }
+        ]
+    }
+
+    def __init__(self, qt_app):
+        super().__init__()
+        self.callback_queue = Queue()
+        self.qt_app = qt_app
+
+    def _create_routes(self):
+        self.websocket_rpc = QtUnrealRpc(
+            self, loop=self.websocket_server.loop
+        )
+        self.websocket_server.add_route(
+            "*", "/ws", self.websocket_rpc.handle_request
+        )
+
+    def execute_in_main_thread(self, main_thread_item, wait=True):
+        """Add `MainThreadItem` to callback queue and wait for result."""
+        self.callback_queue.put(main_thread_item)
+        if wait:
+            return main_thread_item.wait()
+        return
+
+    async def async_execute_in_main_thread(self, main_thread_item, wait=True):
+        """Add `MainThreadItem` to callback queue and wait for result."""
+        self.callback_queue.put(main_thread_item)
+        if wait:
+            return await main_thread_item.async_wait()
+
+    def main_thread_listen(self):
+        """Get last `MainThreadItem` from queue.
+
+        Must be called from main thread.
+
+        Method checks if host process is still running as it may cause
+        issues if not.
+        """
+        # check if host still running
+        if self.process.poll() is not None:
+            self._exit()
+            return None
+
+        if self.callback_queue.empty():
+            return None
+        return self.callback_queue.get()
+
+    def _on_client_connect(self):
+        super()._on_client_connect()
+        self._build_menu()
+
+    def _build_menu(self):
+        self.send_request(
+            "define_menu", [self.menu_definitions]
+        )
+
+    def _exit(self, *args, **kwargs):
+        super()._exit(*args, **kwargs)
+        emit_event("application.exit")
+        self.qt_app.exit(self.exit_code)

--- a/client/ayon_unreal/api/launch_script.py
+++ b/client/ayon_unreal/api/launch_script.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import signal
+import traceback
+import ctypes
+import platform
+import logging
+
+from qtpy import QtCore, QtGui
+
+from ayon_core.hosts.unreal.api.communication_server import (
+    CommunicationWrapper
+)
+from ayon_core.hosts.unreal.api import UnrealHost
+from ayon_core.pipeline import install_host
+from ayon_core.tools.utils import get_openpype_qt_app
+from ayon_core import style
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def safe_excepthook(*args):
+    traceback.print_exception(*args)
+
+
+def main(launch_args):
+
+    # Be sure server won't crash at any moment but just print traceback
+    sys.excepthook = safe_excepthook
+
+    # Create QtApplication for tools
+    # - QApplicaiton is also main thread/event loop of the server
+    qt_app = get_openpype_qt_app()
+
+    unreal_host = UnrealHost()
+    install_host(unreal_host)
+
+    # Create Communicator object and trigger launch
+    # - this must be done before anything is processed
+    communicator = CommunicationWrapper.create_qt_communicator(qt_app)
+    communicator.launch(launch_args)
+
+    # subprocess.Popen(launch_args)
+
+    def process_in_main_thread():
+        """Execution of `MainThreadItem`."""
+        item = communicator.main_thread_listen()
+        if item:
+            item.execute()
+
+    timer = QtCore.QTimer()
+    timer.setInterval(100)
+    timer.timeout.connect(process_in_main_thread)
+    timer.start()
+
+    # Register terminal signal handler
+    def signal_handler(*_args):
+        print("You pressed Ctrl+C. Process ended.")
+        communicator.stop()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    qt_app.setQuitOnLastWindowClosed(False)
+    qt_app.setStyleSheet(style.load_stylesheet())
+
+    # Load avalon icon
+    icon_path = style.app_icon_path()
+    if icon_path:
+        icon = QtGui.QIcon(icon_path)
+        qt_app.setWindowIcon(icon)
+
+    # Set application name to be able show application icon in task bar
+    if platform.system().lower() == "windows":
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+            u"WebsocketServer"
+        )
+
+    # Run Qt application event processing
+    sys.exit(qt_app.exec_())
+
+
+if __name__ == "__main__":
+    args = list(sys.argv)
+    if os.path.abspath(__file__) == os.path.normpath(args[0]):
+        # Pop path to script
+        args.pop(0)
+    main(args)

--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+import ast
 import os
 import json
 import logging
-from typing import List
 from contextlib import contextmanager
 import time
 
@@ -17,17 +17,15 @@ from ayon_core.pipeline import (
     deregister_loader_plugin_path,
     deregister_creator_plugin_path,
     deregister_inventory_action_path,
-    AYON_CONTAINER_ID,
-    get_current_project_name,
 )
 from ayon_core.tools.utils import host_tools
+import ayon_unreal
 from ayon_core.host import HostBase, ILoadHost, IPublishHost
-from ayon_unreal import UNREAL_ADDON_ROOT
-
-import unreal  # noqa
-
+from ayon_unreal.api.communication_server import (
+    CommunicationWrapper
+)
 # Rename to Ayon once parent module renames
-logger = logging.getLogger("ayon_core.hosts.unreal")
+logger = logging.getLogger("ayon_unreal")
 
 AYON_CONTAINERS = "AyonContainers"
 AYON_ASSET_DIR = "/Game/Ayon/Assets"
@@ -36,7 +34,7 @@ UNREAL_VERSION = semver.VersionInfo(
     *os.getenv("AYON_UNREAL_VERSION").split(".")
 )
 
-PLUGINS_DIR = os.path.join(UNREAL_ADDON_ROOT, "plugins")
+PLUGINS_DIR = os.path.join(ayon_unreal.UNREAL_ADDON_ROOT, "plugins")
 PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
@@ -58,18 +56,22 @@ class UnrealHost(HostBase, ILoadHost, IPublishHost):
     def get_containers(self):
         return ls()
 
-    @staticmethod
-    def show_tools_popup():
-        """Show tools popup with actions leading to show other tools."""
-        show_tools_popup()
-
-    @staticmethod
-    def show_tools_dialog():
-        """Show tools dialog with actions leading to show other tools."""
-        show_tools_dialog()
-
     def update_context_data(self, data, changes):
-        content_path = unreal.Paths.project_content_dir()
+        content_path = send_request("project_content_dir")
+
+        unreal_log("Updating context data...", "info")
+
+        # The context json will be stored in the Ayon folder, so we need
+        # to create it if it doesn't exist.
+        dir_exists = send_request(
+            "does_directory_exist",
+            params={"directory_path": "/Game/Ayon"})
+
+        if not dir_exists:
+            send_request(
+                "make_directory",
+                params={"directory_path": "/Game/Ayon"})
+
         op_ctx = content_path + CONTEXT_CONTAINER
         attempts = 3
         for i in range(attempts):
@@ -79,15 +81,16 @@ class UnrealHost(HostBase, ILoadHost, IPublishHost):
                 break
             except IOError as e:
                 if i == attempts - 1:
-                    raise Exception(
+                    raise IOError(
                         "Failed to write context data. Aborting.") from e
-                unreal.log_warning("Failed to write context data. Retrying...")
+                unreal_log(
+                    "Failed to write context data. Retrying...", "warning")
                 i += 1
                 time.sleep(3)
                 continue
 
     def get_context_data(self):
-        content_path = unreal.Paths.project_content_dir()
+        content_path = send_request("project_content_dir")
         op_ctx = content_path + CONTEXT_CONTAINER
         if not os.path.isfile(op_ctx):
             return {}
@@ -156,6 +159,36 @@ def _register_events():
     pass
 
 
+def send_request(request: str, params: dict = None):
+    communicator = CommunicationWrapper.communicator
+    if ret_value := ast.literal_eval(
+        communicator.send_request(request, params)
+    ):
+        return ret_value.get("return")
+    return None
+
+
+def unreal_log(message, level):
+    """Log message to Unreal.
+
+    Args:
+        message (str): message to log
+        level (str): level of message
+
+    """
+    send_request("log", params={"message": message, "level": level})
+
+
+def imprint(node, data):
+    """Imprint data to container.
+
+    Args:
+        node (str): path to container
+        data (dict): data to imprint
+    """
+    send_request("imprint", params={"node": node, "data": data})
+
+
 def ls():
     """List all containers.
 
@@ -163,60 +196,17 @@ def ls():
     metadata from them. Adding `objectName` to set.
 
     """
-    ar = unreal.AssetRegistryHelpers.get_asset_registry()
-    # UE 5.1 changed how class name is specified
-    class_name = ["/Script/Ayon", "AyonAssetContainer"] if UNREAL_VERSION.major == 5 and UNREAL_VERSION.minor > 0 else "AyonAssetContainer"  # noqa
-    ayon_containers = ar.get_assets_by_class(class_name, True)
-
-    # get_asset_by_class returns AssetData. To get all metadata we need to
-    # load asset. get_tag_values() work only on metadata registered in
-    # Asset Registry Project settings (and there is no way to set it with
-    # python short of editing ini configuration file).
-    for asset_data in ayon_containers:
-        asset = asset_data.get_asset()
-        data = unreal.EditorAssetLibrary.get_metadata_tag_values(asset)
-        data["objectName"] = asset_data.asset_name
-        yield cast_map_to_str_dict(data)
+    return send_request("ls")
 
 
 def ls_inst():
-    ar = unreal.AssetRegistryHelpers.get_asset_registry()
-    # UE 5.1 changed how class name is specified
-    class_name = [
-        "/Script/Ayon",
-        "AyonPublishInstance"
-    ] if (
-            UNREAL_VERSION.major == 5
-            and UNREAL_VERSION.minor > 0
-    ) else "AyonPublishInstance"  # noqa
-    instances = ar.get_assets_by_class(class_name, True)
+    """List all containers.
 
-    # get_asset_by_class returns AssetData. To get all metadata we need to
-    # load asset. get_tag_values() work only on metadata registered in
-    # Asset Registry Project settings (and there is no way to set it with
-    # python short of editing ini configuration file).
-    for asset_data in instances:
-        asset = asset_data.get_asset()
-        data = unreal.EditorAssetLibrary.get_metadata_tag_values(asset)
-        data["objectName"] = asset_data.asset_name
-        yield cast_map_to_str_dict(data)
+    List all found in *Content Manager* of Unreal and return
+    metadata from them. Adding `objectName` to set.
 
-
-def parse_container(container):
-    """To get data from container, AyonAssetContainer must be loaded.
-
-    Args:
-        container(str): path to container
-
-    Returns:
-        dict: metadata stored on container
     """
-    asset = unreal.EditorAssetLibrary.load_asset(container)
-    data = unreal.EditorAssetLibrary.get_metadata_tag_values(asset)
-    data["objectName"] = asset.get_name()
-    data = cast_map_to_str_dict(data)
-
-    return data
+    return send_request("ls_inst")
 
 
 def publish():
@@ -226,7 +216,7 @@ def publish():
     return pyblish.util.publish()
 
 
-def containerise(name, namespace, nodes, context, loader=None, suffix="_CON"):
+def containerise(root, name, data, suffix="_CON"):
     """Bundles *nodes* (assets) into a *container* and add metadata to it.
 
     Unreal doesn't support *groups* of assets that you can add metadata to.
@@ -244,28 +234,13 @@ def containerise(name, namespace, nodes, context, loader=None, suffix="_CON"):
     `Material /Game/Ayon/Test/TestMaterial.TestMaterial`
 
     """
-    # 1 - create directory for container
-    root = "/Game"
-    container_name = f"{name}{suffix}"
-    new_name = move_assets_to_path(root, container_name, nodes)
-
-    # 2 - create Asset Container there
-    path = f"{root}/{new_name}"
-    create_container(container=container_name, path=path)
-
-    namespace = path
-
-    data = {
-        "schema": "ayon:container-2.0",
-        "id": AYON_CONTAINER_ID,
-        "name": new_name,
-        "namespace": namespace,
-        "loader": str(loader),
-        "representation": context["representation"]["id"],
-    }
-    # 3 - imprint data
-    imprint(f"{path}/{container_name}", data)
-    return path
+    return send_request(
+        "containerise",
+        params={
+            "root": root,
+            "name": name,
+            "data": data,
+            "suffix": suffix})
 
 
 def instantiate(root, name, data, assets=None, suffix="_INS"):
@@ -286,56 +261,13 @@ def instantiate(root, name, data, assets=None, suffix="_INS"):
         suffix (str): suffix string to append to instance name
 
     """
-    container_name = f"{name}{suffix}"
-
-    # if we specify assets, create new folder and move them there. If not,
-    # just create empty folder
-    if assets:
-        new_name = move_assets_to_path(root, container_name, assets)
-    else:
-        new_name = create_folder(root, name)
-
-    path = f"{root}/{new_name}"
-    create_publish_instance(instance=container_name, path=path)
-
-    imprint(f"{path}/{container_name}", data)
-
-
-def imprint(node, data):
-    loaded_asset = unreal.EditorAssetLibrary.load_asset(node)
-    for key, value in data.items():
-        # Support values evaluated at imprint
-        if callable(value):
-            value = value()
-        # Unreal doesn't support NoneType in metadata values
-        if value is None:
-            value = ""
-        unreal.EditorAssetLibrary.set_metadata_tag(
-            loaded_asset, key, str(value)
-        )
-
-    with unreal.ScopedEditorTransaction("Ayon containerising"):
-        unreal.EditorAssetLibrary.save_asset(node)
-
-
-def show_tools_popup():
-    """Show popup with tools.
-
-    Popup will disappear on click or losing focus.
-    """
-    from ayon_unreal.api import tools_ui
-
-    tools_ui.show_tools_popup()
-
-
-def show_tools_dialog():
-    """Show dialog with tools.
-
-    Dialog will stay visible.
-    """
-    from ayon_unreal.api import tools_ui
-
-    tools_ui.show_tools_dialog()
+    return send_request(
+        "instantiate", params={
+            "root": root,
+            "name": name,
+            "data": data,
+            "assets": assets,
+            "suffix": suffix})
 
 
 def show_creator():
@@ -358,442 +290,9 @@ def show_experimental_tools():
     host_tools.show_experimental_tools_dialog()
 
 
-def create_folder(root: str, name: str) -> str:
-    """Create new folder.
-
-    If folder exists, append number at the end and try again, incrementing
-    if needed.
-
-    Args:
-        root (str): path root
-        name (str): folder name
-
-    Returns:
-        str: folder name
-
-    Example:
-        >>> create_folder("/Game/Foo")
-        /Game/Foo
-        >>> create_folder("/Game/Foo")
-        /Game/Foo1
-
-    """
-    eal = unreal.EditorAssetLibrary
-    index = 1
-    while True:
-        if eal.does_directory_exist(f"{root}/{name}"):
-            name = f"{name}{index}"
-            index += 1
-        else:
-            eal.make_directory(f"{root}/{name}")
-            break
-
-    return name
-
-
-def move_assets_to_path(root: str, name: str, assets: List[str]) -> str:
-    """Moving (renaming) list of asset paths to new destination.
-
-    Args:
-        root (str): root of the path (eg. `/Game`)
-        name (str): name of destination directory (eg. `Foo` )
-        assets (list of str): list of asset paths
-
-    Returns:
-        str: folder name
-
-    Example:
-        This will get paths of all assets under `/Game/Test` and move them
-        to `/Game/NewTest`. If `/Game/NewTest` already exists, then resulting
-        path will be `/Game/NewTest1`
-
-        >>> assets = unreal.EditorAssetLibrary.list_assets("/Game/Test")
-        >>> move_assets_to_path("/Game", "NewTest", assets)
-        NewTest
-
-    """
-    eal = unreal.EditorAssetLibrary
-    name = create_folder(root, name)
-
-    unreal.log(assets)
-    for asset in assets:
-        loaded = eal.load_asset(asset)
-        eal.rename_asset(asset, f"{root}/{name}/{loaded.get_name()}")
-
-    return name
-
-
-def create_container(container: str, path: str) -> unreal.Object:
-    """Helper function to create Asset Container class on given path.
-
-    This Asset Class helps to mark given path as Container
-    and enable asset version control on it.
-
-    Args:
-        container (str): Asset Container name
-        path (str): Path where to create Asset Container. This path should
-            point into container folder
-
-    Returns:
-        :class:`unreal.Object`: instance of created asset
-
-    Example:
-
-        create_container(
-            "/Game/modelingFooCharacter_CON",
-            "modelingFooCharacter_CON"
-        )
-
-    """
-    factory = unreal.AyonAssetContainerFactory()
-    tools = unreal.AssetToolsHelpers().get_asset_tools()
-
-    return tools.create_asset(container, path, None, factory)
-
-
-def create_publish_instance(instance: str, path: str) -> unreal.Object:
-    """Helper function to create Ayon Publish Instance on given path.
-
-    This behaves similarly as :func:`create_ayon_container`.
-
-    Args:
-        path (str): Path where to create Publish Instance.
-            This path should point into container folder
-        instance (str): Publish Instance name
-
-    Returns:
-        :class:`unreal.Object`: instance of created asset
-
-    Example:
-
-        create_publish_instance(
-            "/Game/modelingFooCharacter_INST",
-            "modelingFooCharacter_INST"
-        )
-
-    """
-    factory = unreal.AyonPublishInstanceFactory()
-    tools = unreal.AssetToolsHelpers().get_asset_tools()
-    return tools.create_asset(instance, path, None, factory)
-
-
-def cast_map_to_str_dict(umap) -> dict:
-    """Cast Unreal Map to dict.
-
-    Helper function to cast Unreal Map object to plain old python
-    dict. This will also cast values and keys to str. Useful for
-    metadata dicts.
-
-    Args:
-        umap: Unreal Map object
-
-    Returns:
-        dict
-
-    """
-    return {str(key): str(value) for (key, value) in umap.items()}
-
-
-def get_subsequences(sequence: unreal.LevelSequence):
-    """Get list of subsequences from sequence.
-
-    Args:
-        sequence (unreal.LevelSequence): Sequence
-
-    Returns:
-        list(unreal.LevelSequence): List of subsequences
-
-    """
-    tracks = sequence.get_master_tracks()
-    subscene_track = next(
-        (
-            t
-            for t in tracks
-            if t.get_class() == unreal.MovieSceneSubTrack.static_class()
-        ),
-        None,
-    )
-    if subscene_track is not None and subscene_track.get_sections():
-        return subscene_track.get_sections()
-    return []
-
-
-def set_sequence_hierarchy(
-    seq_i, seq_j, max_frame_i, min_frame_j, max_frame_j, map_paths
-):
-    # Get existing sequencer tracks or create them if they don't exist
-    tracks = seq_i.get_master_tracks()
-    subscene_track = None
-    visibility_track = None
-    for t in tracks:
-        if t.get_class() == unreal.MovieSceneSubTrack.static_class():
-            subscene_track = t
-        if (t.get_class() ==
-                unreal.MovieSceneLevelVisibilityTrack.static_class()):
-            visibility_track = t
-    if not subscene_track:
-        subscene_track = seq_i.add_master_track(unreal.MovieSceneSubTrack)
-    if not visibility_track:
-        visibility_track = seq_i.add_master_track(
-            unreal.MovieSceneLevelVisibilityTrack)
-
-    # Create the sub-scene section
-    subscenes = subscene_track.get_sections()
-    subscene = None
-    for s in subscenes:
-        if s.get_editor_property('sub_sequence') == seq_j:
-            subscene = s
-            break
-    if not subscene:
-        subscene = subscene_track.add_section()
-        subscene.set_row_index(len(subscene_track.get_sections()))
-        subscene.set_editor_property('sub_sequence', seq_j)
-        subscene.set_range(
-            min_frame_j,
-            max_frame_j + 1)
-
-    # Create the visibility section
-    ar = unreal.AssetRegistryHelpers.get_asset_registry()
-    maps = []
-    for m in map_paths:
-        # Unreal requires to load the level to get the map name
-        unreal.EditorLevelLibrary.save_all_dirty_levels()
-        unreal.EditorLevelLibrary.load_level(m)
-        maps.append(str(ar.get_asset_by_object_path(m).asset_name))
-
-    vis_section = visibility_track.add_section()
-    index = len(visibility_track.get_sections())
-
-    vis_section.set_range(
-        min_frame_j,
-        max_frame_j + 1)
-    vis_section.set_visibility(unreal.LevelVisibility.VISIBLE)
-    vis_section.set_row_index(index)
-    vis_section.set_level_names(maps)
-
-    if min_frame_j > 1:
-        hid_section = visibility_track.add_section()
-        hid_section.set_range(
-            1,
-            min_frame_j)
-        hid_section.set_visibility(unreal.LevelVisibility.HIDDEN)
-        hid_section.set_row_index(index)
-        hid_section.set_level_names(maps)
-    if max_frame_j < max_frame_i:
-        hid_section = visibility_track.add_section()
-        hid_section.set_range(
-            max_frame_j + 1,
-            max_frame_i + 1)
-        hid_section.set_visibility(unreal.LevelVisibility.HIDDEN)
-        hid_section.set_row_index(index)
-        hid_section.set_level_names(maps)
-
-
-def generate_sequence(h, h_dir):
-    tools = unreal.AssetToolsHelpers().get_asset_tools()
-
-    sequence = tools.create_asset(
-        asset_name=h,
-        package_path=h_dir,
-        asset_class=unreal.LevelSequence,
-        factory=unreal.LevelSequenceFactoryNew()
-    )
-
-    project_name = get_current_project_name()
-    # TODO Fix this does not return folder path
-    folder_path = h_dir.split('/')[-1],
-    folder_entity = ayon_api.get_folder_by_path(
-        project_name,
-        folder_path,
-        fields={"id", "attrib.fps"}
-    )
-
-    start_frames = []
-    end_frames = []
-
-    elements = list(ayon_api.get_folders(
-        project_name,
-        parent_ids=[folder_entity["id"]],
-        fields={"id", "attrib.clipIn", "attrib.clipOut"}
-    ))
-    for e in elements:
-        start_frames.append(e["attrib"].get("clipIn"))
-        end_frames.append(e["attrib"].get("clipOut"))
-
-        elements.extend(ayon_api.get_folders(
-            project_name,
-            parent_ids=[e["id"]],
-            fields={"id", "attrib.clipIn", "attrib.clipOut"}
-        ))
-
-    min_frame = min(start_frames)
-    max_frame = max(end_frames)
-
-    fps = folder_entity["attrib"].get("fps")
-
-    sequence.set_display_rate(
-        unreal.FrameRate(fps, 1.0))
-    sequence.set_playback_start(min_frame)
-    sequence.set_playback_end(max_frame)
-
-    sequence.set_work_range_start(min_frame / fps)
-    sequence.set_work_range_end(max_frame / fps)
-    sequence.set_view_range_start(min_frame / fps)
-    sequence.set_view_range_end(max_frame / fps)
-
-    tracks = sequence.get_master_tracks()
-    track = None
-    for t in tracks:
-        if (t.get_class() ==
-                unreal.MovieSceneCameraCutTrack.static_class()):
-            track = t
-            break
-    if not track:
-        track = sequence.add_master_track(
-            unreal.MovieSceneCameraCutTrack)
-
-    return sequence, (min_frame, max_frame)
-
-
-def _get_comps_and_assets(
-    component_class, asset_class, old_assets, new_assets, selected
-):
-    eas = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
-
-    components = []
-    if selected:
-        sel_actors = eas.get_selected_level_actors()
-        for actor in sel_actors:
-            comps = actor.get_components_by_class(component_class)
-            components.extend(comps)
-    else:
-        comps = eas.get_all_level_actors_components()
-        components = [
-            c for c in comps if isinstance(c, component_class)
-        ]
-
-    # Get all the static meshes among the old assets in a dictionary with
-    # the name as key
-    selected_old_assets = {}
-    for a in old_assets:
-        asset = unreal.EditorAssetLibrary.load_asset(a)
-        if isinstance(asset, asset_class):
-            selected_old_assets[asset.get_name()] = asset
-
-    # Get all the static meshes among the new assets in a dictionary with
-    # the name as key
-    selected_new_assets = {}
-    for a in new_assets:
-        asset = unreal.EditorAssetLibrary.load_asset(a)
-        if isinstance(asset, asset_class):
-            selected_new_assets[asset.get_name()] = asset
-
-    return components, selected_old_assets, selected_new_assets
-
-
-def replace_static_mesh_actors(old_assets, new_assets, selected):
-    smes = unreal.get_editor_subsystem(unreal.StaticMeshEditorSubsystem)
-
-    static_mesh_comps, old_meshes, new_meshes = _get_comps_and_assets(
-        unreal.StaticMeshComponent,
-        unreal.StaticMesh,
-        old_assets,
-        new_assets,
-        selected
-    )
-
-    for old_name, old_mesh in old_meshes.items():
-        new_mesh = new_meshes.get(old_name)
-
-        if not new_mesh:
-            continue
-
-        smes.replace_mesh_components_meshes(
-            static_mesh_comps, old_mesh, new_mesh)
-
-
-def replace_skeletal_mesh_actors(old_assets, new_assets, selected):
-    skeletal_mesh_comps, old_meshes, new_meshes = _get_comps_and_assets(
-        unreal.SkeletalMeshComponent,
-        unreal.SkeletalMesh,
-        old_assets,
-        new_assets,
-        selected
-    )
-
-    for old_name, old_mesh in old_meshes.items():
-        new_mesh = new_meshes.get(old_name)
-
-        if not new_mesh:
-            continue
-
-        for comp in skeletal_mesh_comps:
-            if comp.get_skeletal_mesh_asset() == old_mesh:
-                comp.set_skeletal_mesh_asset(new_mesh)
-
-
-def replace_geometry_cache_actors(old_assets, new_assets, selected):
-    geometry_cache_comps, old_caches, new_caches = _get_comps_and_assets(
-        unreal.GeometryCacheComponent,
-        unreal.GeometryCache,
-        old_assets,
-        new_assets,
-        selected
-    )
-
-    for old_name, old_mesh in old_caches.items():
-        new_mesh = new_caches.get(old_name)
-
-        if not new_mesh:
-            continue
-
-        for comp in geometry_cache_comps:
-            if comp.get_editor_property("geometry_cache") == old_mesh:
-                comp.set_geometry_cache(new_mesh)
-
-
-def delete_asset_if_unused(container, asset_content):
-    ar = unreal.AssetRegistryHelpers.get_asset_registry()
-
-    references = set()
-
-    for asset_path in asset_content:
-        asset = ar.get_asset_by_object_path(asset_path)
-        refs = ar.get_referencers(
-            asset.package_name,
-            unreal.AssetRegistryDependencyOptions(
-                include_soft_package_references=False,
-                include_hard_package_references=True,
-                include_searchable_names=False,
-                include_soft_management_references=False,
-                include_hard_management_references=False
-            ))
-        if not refs:
-            continue
-        references = references.union(set(refs))
-
-    # Filter out references that are in the Temp folder
-    cleaned_references = {
-        ref for ref in references if not str(ref).startswith("/Temp/")}
-
-    # Check which of the references are Levels
-    for ref in cleaned_references:
-        loaded_asset = unreal.EditorAssetLibrary.load_asset(ref)
-        if isinstance(loaded_asset, unreal.World):
-            # If there is at least a level, we can stop, we don't want to
-            # delete the container
-            return
-
-    unreal.log("Previous version unused, deleting...")
-
-    # No levels, delete the asset
-    unreal.EditorAssetLibrary.delete_directory(container["namespace"])
-
-
 @contextmanager
 def maintained_selection():
     """Stub to be either implemented or replaced.
-
     This is needed for old publisher implementation, but
     it is not supported (yet) in UE.
     """

--- a/client/ayon_unreal/api/plugin.py
+++ b/client/ayon_unreal/api/plugin.py
@@ -3,19 +3,8 @@ import ast
 import collections
 import sys
 import six
-from abc import (
-    ABC,
-    ABCMeta,
-)
+from abc import ABCMeta
 
-import unreal
-
-from .pipeline import (
-    create_publish_instance,
-    imprint,
-    ls_inst,
-    UNREAL_VERSION
-)
 from ayon_core.lib import (
     BoolDef,
     UILabelDef
@@ -25,6 +14,13 @@ from ayon_core.pipeline import (
     LoaderPlugin,
     CreatorError,
     CreatedInstance
+)
+from ayon_unreal.api.pipeline import (
+    send_request,
+    unreal_log,
+    ls_inst,
+    imprint,
+    instantiate
 )
 
 
@@ -71,7 +67,6 @@ class UnrealBaseCreator(Creator):
     def create(self, product_name, instance_data, pre_create_data):
         try:
             instance_name = f"{product_name}{self.suffix}"
-            pub_instance = create_publish_instance(instance_name, self.root)
 
             instance_data["productName"] = product_name
             instance_data["instance_path"] = f"{self.root}/{instance_name}"
@@ -83,16 +78,11 @@ class UnrealBaseCreator(Creator):
                 self)
             self._add_instance_to_context(instance)
 
-            pub_instance.set_editor_property('add_external_assets', True)
-            assets = pub_instance.get_editor_property('asset_data_external')
-
-            ar = unreal.AssetRegistryHelpers.get_asset_registry()
-
-            for member in pre_create_data.get("members", []):
-                obj = ar.get_asset_by_object_path(member).get_asset()
-                assets.add(obj)
-
-            imprint(f"{self.root}/{instance_name}", instance.data_to_store())
+            instantiate(
+                self.root,
+                instance_name,
+                instance.data_to_store(),
+                pre_create_data.get("members", []))
 
             return instance
 
@@ -120,24 +110,21 @@ class UnrealBaseCreator(Creator):
             instance_node = created_inst.get("instance_path", "")
 
             if not instance_node:
-                unreal.log_warning(
-                    f"Instance node not found for {created_inst}")
+                message = f"Instance node not found for {created_inst}"
+                unreal_log(message, "warning")
                 continue
 
             new_values = {
                 key: changes[key].new_value
                 for key in changes.changed_keys
             }
-            imprint(
-                instance_node,
-                new_values
-            )
+            imprint(instance_node, new_values)
 
     def remove_instances(self, instances):
         for instance in instances:
-            instance_node = instance.data.get("instance_path", "")
-            if instance_node:
-                unreal.EditorAssetLibrary.delete_asset(instance_node)
+            if instance_node := instance.data.get("instance_path", ""):
+                send_request(
+                    "delete_asset", params={"asset_path": instance_node})
 
             self._remove_instance_from_context(instance)
 
@@ -164,10 +151,8 @@ class UnrealAssetCreator(UnrealBaseCreator):
                 pre_create_data["members"] = []
 
                 if pre_create_data.get("use_selection"):
-                    utilib = unreal.EditorUtilityLibrary
-                    sel_objects = utilib.get_selected_assets()
-                    pre_create_data["members"] = [
-                        a.get_path_name() for a in sel_objects]
+                    pre_create_data["members"] = send_request(
+                        "get_selected_assets")
 
             super(UnrealAssetCreator, self).create(
                 product_name,
@@ -202,26 +187,20 @@ class UnrealActorCreator(UnrealBaseCreator):
             CreatedInstance: Created instance.
         """
         try:
-            if UNREAL_VERSION.major == 5:
-                world = unreal.UnrealEditorSubsystem().get_editor_world()
-            else:
-                world = unreal.EditorLevelLibrary.get_editor_world()
+            world = send_request("get_editor_world")
 
             # Check if the level is saved
-            if world.get_path_name().startswith("/Temp/"):
+            if world.startswith("/Temp/"):
                 raise CreatorError(
                     "Level must be saved before creating instances.")
 
             # Check if instance data has members, filled by the plugin.
             # If not, use selection.
             if not instance_data.get("members"):
-                actor_subsystem = unreal.EditorActorSubsystem()
-                sel_actors = actor_subsystem.get_selected_level_actors()
-                selection = [a.get_path_name() for a in sel_actors]
+                instance_data["members"] = send_request(
+                    "get_selected_actors")
 
-                instance_data["members"] = selection
-
-            instance_data["level"] = world.get_path_name()
+            instance_data["level"] = world
 
             super(UnrealActorCreator, self).create(
                 product_name,
@@ -240,6 +219,26 @@ class UnrealActorCreator(UnrealBaseCreator):
         ]
 
 
-class Loader(LoaderPlugin, ABC):
-    """This serves as skeleton for future Ayon specific functionality"""
-    pass
+@six.add_metaclass(ABCMeta)
+class UnrealBaseLoader(LoaderPlugin):
+    """Base class for Unreal loader plugins."""
+    root = "/Game/Ayon"
+    suffix = "_CON"
+
+    def update(self, container, context):
+        repre_entity = context["representation"]
+
+        asset_dir = container["namespace"]
+        container_name = container['objectName']
+
+        data = {
+            "representation": str(repre_entity["id"]),
+            "parent": str(repre_entity["versionId"])
+        }
+
+        imprint(f"{asset_dir}/{container_name}", data)
+
+    def remove(self, container):
+        path = container["namespace"]
+
+        send_request("remove_asset", params={"path": path})

--- a/client/ayon_unreal/api/rendering.py
+++ b/client/ayon_unreal/api/rendering.py
@@ -1,45 +1,22 @@
 import os
 
-import unreal
-
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import Anatomy
 from ayon_core.tools.utils import show_message_dialog
-from ayon_unreal.api import pipeline
-
-
-queue = None
-executor = None
-
-
-def _queue_finish_callback(exec, success):
-    unreal.log("Render completed. Success: " + str(success))
-
-    # Delete our reference so we don't keep it alive.
-    global executor
-    global queue
-    del executor
-    del queue
-
-
-def _job_finish_callback(job, success):
-    # You can make any edits you want to the editor world here, and the world
-    # will be duplicated when the next render happens. Make sure you undo your
-    # edits in OnQueueFinishedCallback if you don't want to leak state changes
-    # into the editor world.
-    unreal.log("Individual job completed.")
+from ayon_unreal.api.pipeline import (
+    send_request,
+)
 
 
 def start_rendering():
     """
     Start the rendering process.
     """
-    unreal.log("Starting rendering...")
 
     # Get selected sequences
-    assets = unreal.EditorUtilityLibrary.get_selected_assets()
+    selection = send_request("get_selected_assets")
 
-    if not assets:
+    if not selection:
         show_message_dialog(
             title="No assets selected",
             message="No assets selected. Select a render instance.",
@@ -47,134 +24,26 @@ def start_rendering():
         raise RuntimeError(
             "No assets selected. You need to select a render instance.")
 
-    # instances = pipeline.ls_inst()
-    instances = [
-        a for a in assets
-        if a.get_class().get_name() == "AyonPublishInstance"]
-
-    inst_data = []
-
-    for i in instances:
-        data = pipeline.parse_container(i.get_path_name())
-        if data["productType"] == "render":
-            inst_data.append(data)
-
     try:
         project = os.environ.get("AYON_PROJECT_NAME")
         anatomy = Anatomy(project)
         root = anatomy.roots['renders']
     except Exception as e:
-        raise Exception(
+        raise RuntimeError(
             "Could not find render root in anatomy settings.") from e
 
     render_dir = f"{root}/{project}"
 
-    # subsystem = unreal.get_editor_subsystem(
-    #     unreal.MoviePipelineQueueSubsystem)
-    # queue = subsystem.get_queue()
-    global queue
-    queue = unreal.MoviePipelineQueue()
-
-    ar = unreal.AssetRegistryHelpers.get_asset_registry()
-
     data = get_project_settings(project)
-    config = None
-    config_path = str(data.get("unreal").get("render_config_path"))
-    if config_path and unreal.EditorAssetLibrary.does_asset_exist(config_path):
-        unreal.log("Found saved render configuration")
-        config = ar.get_asset_by_object_path(config_path).get_asset()
+    config_path = data.get("unreal").get("render_config_path")
+    render_format = data.get("unreal").get("render_format", "png")
+    preroll_frames = data.get("unreal").get("preroll_frames", 0)
 
-    for i in inst_data:
-        sequence = ar.get_asset_by_object_path(i["sequence"]).get_asset()
-
-        sequences = [{
-            "sequence": sequence,
-            "output": f"{i['output']}",
-            "frame_range": (
-                int(float(i["frameStart"])),
-                int(float(i["frameEnd"])) + 1)
-        }]
-        render_list = []
-
-        # Get all the sequences to render. If there are subsequences,
-        # add them and their frame ranges to the render list. We also
-        # use the names for the output paths.
-        for seq in sequences:
-            subscenes = pipeline.get_subsequences(seq.get('sequence'))
-
-            if subscenes:
-                for sub_seq in subscenes:
-                    sequences.append({
-                        "sequence": sub_seq.get_sequence(),
-                        "output": (f"{seq.get('output')}/"
-                                   f"{sub_seq.get_sequence().get_name()}"),
-                        "frame_range": (
-                            sub_seq.get_start_frame(), sub_seq.get_end_frame())
-                    })
-            else:
-                # Avoid rendering camera sequences
-                if "_camera" not in seq.get('sequence').get_name():
-                    render_list.append(seq)
-
-        # Create the rendering jobs and add them to the queue.
-        for render_setting in render_list:
-            job = queue.allocate_new_job(unreal.MoviePipelineExecutorJob)
-            job.sequence = unreal.SoftObjectPath(i["master_sequence"])
-            job.map = unreal.SoftObjectPath(i["master_level"])
-            job.author = "Ayon"
-
-            # If we have a saved configuration, copy it to the job.
-            if config:
-                job.get_configuration().copy_from(config)
-
-            # User data could be used to pass data to the job, that can be
-            # read in the job's OnJobFinished callback. We could,
-            # for instance, pass the AyonPublishInstance's path to the job.
-            # job.user_data = ""
-
-            output_dir = render_setting.get('output')
-            shot_name = render_setting.get('sequence').get_name()
-
-            settings = job.get_configuration().find_or_add_setting_by_class(
-                unreal.MoviePipelineOutputSetting)
-            settings.output_resolution = unreal.IntPoint(1920, 1080)
-            settings.custom_start_frame = render_setting.get("frame_range")[0]
-            settings.custom_end_frame = render_setting.get("frame_range")[1]
-            settings.use_custom_playback_range = True
-            settings.file_name_format = f"{shot_name}" + ".{frame_number}"
-            settings.output_directory.path = f"{render_dir}/{output_dir}"
-
-            job.get_configuration().find_or_add_setting_by_class(
-                unreal.MoviePipelineDeferredPassBase)
-
-            render_format = data.get("unreal").get("render_format", "png")
-
-            if render_format == "png":
-                job.get_configuration().find_or_add_setting_by_class(
-                    unreal.MoviePipelineImageSequenceOutput_PNG)
-            elif render_format == "exr":
-                job.get_configuration().find_or_add_setting_by_class(
-                    unreal.MoviePipelineImageSequenceOutput_EXR)
-            elif render_format == "jpg":
-                job.get_configuration().find_or_add_setting_by_class(
-                    unreal.MoviePipelineImageSequenceOutput_JPG)
-            elif render_format == "bmp":
-                job.get_configuration().find_or_add_setting_by_class(
-                    unreal.MoviePipelineImageSequenceOutput_BMP)
-
-    # If there are jobs in the queue, start the rendering process.
-    if queue.get_jobs():
-        global executor
-        executor = unreal.MoviePipelinePIEExecutor()
-
-        preroll_frames = data.get("unreal").get("preroll_frames", 0)
-
-        settings = unreal.MoviePipelinePIEExecutorSettings()
-        settings.set_editor_property(
-            "initial_delay_frame_count", preroll_frames)
-
-        executor.on_executor_finished_delegate.add_callable_unique(
-            _queue_finish_callback)
-        executor.on_individual_job_finished_delegate.add_callable_unique(
-            _job_finish_callback)  # Only available on PIE Executor
-        executor.execute(queue)
+    send_request(
+        "start_rendering",
+        params={
+            "selection": selection,
+            "render_dir": render_dir,
+            "config_path": config_path,
+            "render_format": render_format,
+            "preroll_frames": preroll_frames})

--- a/client/ayon_unreal/hooks/pre_workfile_preparation.py
+++ b/client/ayon_unreal/hooks/pre_workfile_preparation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from qtpy import QtCore
 
 from ayon_core import resources
+from ayon_core.lib import get_ayon_launcher_args
 from ayon_applications import (
     PreLaunchHook,
     ApplicationLaunchFailed,
@@ -248,6 +249,20 @@ class UnrealPrelaunchHook(PreLaunchHook):
                     )) from e
 
         self.launch_context.env["AYON_UNREAL_VERSION"] = engine_version
+
+        # Prepare new launch arguments
+        new_launch_args = get_ayon_launcher_args(
+            "run", self.launch_script_path(), executable,
+        )
+
+        # Append as whole list as these arguments should not be separated
+        self.launch_context.launch_args = new_launch_args
+
         # Append project file to launch arguments
         self.launch_context.launch_args.append(
             f"\"{project_file.as_posix()}\"")
+
+    def launch_script_path(self):
+        from ayon_unreal.addon import get_launch_script_path
+
+        return get_launch_script_path()

--- a/client/ayon_unreal/lib.py
+++ b/client/ayon_unreal/lib.py
@@ -326,8 +326,6 @@ def create_unreal_project(project_name: str,
         raise NotImplementedError("Unsupported platform")
     if not python_path.exists():
         raise RuntimeError(f"Unreal Python not found at {python_path}")
-    subprocess.check_call(
-        [python_path.as_posix(), "-m", "pip", "install", "pyside2"])
 
 
 def get_path_to_uat(engine_path: Path) -> Path:

--- a/client/ayon_unreal/plugins/create/create_camera.py
+++ b/client/ayon_unreal/plugins/create/create_camera.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import unreal
-
 from ayon_core.pipeline import CreatorError
-from ayon_unreal.api.pipeline import UNREAL_VERSION
+from ayon_unreal.api.pipeline import (
+    send_request,
+)
 from ayon_unreal.api.plugin import (
     UnrealAssetCreator,
 )
@@ -18,19 +18,13 @@ class CreateCamera(UnrealAssetCreator):
 
     def create(self, product_name, instance_data, pre_create_data):
         if pre_create_data.get("use_selection"):
-            sel_objects = unreal.EditorUtilityLibrary.get_selected_assets()
-            selection = [a.get_path_name() for a in sel_objects]
+            selection = send_request("get_selected_assets")
 
             if len(selection) != 1:
                 raise CreatorError("Please select only one object.")
 
         # Add the current level path to the metadata
-        if UNREAL_VERSION.major == 5:
-            world = unreal.UnrealEditorSubsystem().get_editor_world()
-        else:
-            world = unreal.EditorLevelLibrary.get_editor_world()
-
-        instance_data["level"] = world.get_path_name()
+        instance_data["level"] = send_request("get_editor_world")
 
         super(CreateCamera, self).create(
             product_name,

--- a/client/ayon_unreal/plugins/create/create_look.py
+++ b/client/ayon_unreal/plugins/create/create_look.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-import unreal
-
 from ayon_core.pipeline import CreatorError
 from ayon_unreal.api.pipeline import (
-    create_folder
+    send_request,
 )
 from ayon_unreal.api.plugin import (
     UnrealAssetCreator
@@ -22,8 +20,7 @@ class CreateLook(UnrealAssetCreator):
     def create(self, product_name, instance_data, pre_create_data):
         # We need to set this to True for the parent class to work
         pre_create_data["use_selection"] = True
-        sel_objects = unreal.EditorUtilityLibrary.get_selected_assets()
-        selection = [a.get_path_name() for a in sel_objects]
+        selection = send_request("get_selected_assets")
 
         if len(selection) != 1:
             raise CreatorError("Please select only one asset.")
@@ -33,38 +30,16 @@ class CreateLook(UnrealAssetCreator):
         look_directory = "/Game/Ayon/Looks"
 
         # Create the folder
-        folder_name = create_folder(look_directory, product_name)
+        folder_name = send_request(
+            "create_folder",
+            params={"root": look_directory, "name": product_name})
         path = f"{look_directory}/{folder_name}"
 
         instance_data["look"] = path
 
-        # Create a new cube static mesh
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
-        cube = ar.get_asset_by_object_path("/Engine/BasicShapes/Cube.Cube")
-
-        # Get the mesh of the selected object
-        original_mesh = ar.get_asset_by_object_path(selected_asset).get_asset()
-        materials = original_mesh.get_editor_property('static_materials')
-
-        pre_create_data["members"] = []
-
-        # Add the materials to the cube
-        for material in materials:
-            mat_name = material.get_editor_property('material_slot_name')
-            object_path = f"{path}/{mat_name}.{mat_name}"
-            unreal_object = unreal.EditorAssetLibrary.duplicate_loaded_asset(
-                cube.get_asset(), object_path
-            )
-
-            # Remove the default material of the cube object
-            unreal_object.get_editor_property('static_materials').pop()
-
-            unreal_object.add_material(
-                material.get_editor_property('material_interface'))
-
-            pre_create_data["members"].append(object_path)
-
-            unreal.EditorAssetLibrary.save_asset(object_path)
+        pre_create_data["members"] = send_request(
+            "create_look",
+            params={"path": path, "selected_asset": selected_asset})
 
         super(CreateLook, self).create(
             product_name,

--- a/client/ayon_unreal/plugins/create/create_render.py
+++ b/client/ayon_unreal/plugins/create/create_render.py
@@ -1,16 +1,11 @@
 # -*- coding: utf-8 -*-
-from pathlib import Path
-
-import unreal
-
-from ayon_unreal.api.pipeline import (
-    UNREAL_VERSION,
-    create_folder,
-    get_subsequences,
-)
 from ayon_unreal.api.plugin import (
     UnrealAssetCreator
 )
+from ayon_unreal.api.pipeline import (
+    send_request
+)
+from ayon_core.pipeline import CreatorError
 from ayon_core.lib import (
     UILabelDef,
     UISeparatorDef,
@@ -49,178 +44,48 @@ class CreateRender(UnrealAssetCreator):
     ):
         # If the option to create a new level sequence is selected,
         # create a new level sequence and a master level.
-
         root = "/Game/Ayon/Sequences"
+        sequence_dir = f"{root}/{product_name}"
 
-        # Create a new folder for the sequence in root
-        sequence_dir_name = create_folder(root, product_name)
-        sequence_dir = f"{root}/{sequence_dir_name}"
+        master_lvl, sequence, seq_data = send_request(
+            "create_render_with_new_sequence",
+            params={
+                "sequence_dir": sequence_dir,
+                "subset_name": product_name,
+                "start_frame": pre_create_data.get("start_frame"),
+                "end_frame": pre_create_data.get("end_frame")
+            })
 
-        unreal.log_warning(f"sequence_dir: {sequence_dir}")
-
-        # Create the level sequence
-        asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
-        seq = asset_tools.create_asset(
-            asset_name=product_name,
-            package_path=sequence_dir,
-            asset_class=unreal.LevelSequence,
-            factory=unreal.LevelSequenceFactoryNew())
-
-        seq.set_playback_start(pre_create_data.get("start_frame"))
-        seq.set_playback_end(pre_create_data.get("end_frame"))
-
-        pre_create_data["members"] = [seq.get_path_name()]
-
-        unreal.EditorAssetLibrary.save_asset(seq.get_path_name())
-
-        # Create the master level
-        if UNREAL_VERSION.major >= 5:
-            curr_level = unreal.LevelEditorSubsystem().get_current_level()
-        else:
-            world = unreal.EditorLevelLibrary.get_editor_world()
-            levels = unreal.EditorLevelUtils.get_levels(world)
-            curr_level = levels[0] if len(levels) else None
-            if not curr_level:
-                raise RuntimeError("No level loaded.")
-        curr_level_path = curr_level.get_outer().get_path_name()
-
-        # If the level path does not start with "/Game/", the current
-        # level is a temporary, unsaved level.
-        if curr_level_path.startswith("/Game/"):
-            if UNREAL_VERSION.major >= 5:
-                unreal.LevelEditorSubsystem().save_current_level()
-            else:
-                unreal.EditorLevelLibrary.save_current_level()
-
-        ml_path = f"{sequence_dir}/{product_name}_MasterLevel"
-
-        if UNREAL_VERSION.major >= 5:
-            unreal.LevelEditorSubsystem().new_level(ml_path)
-        else:
-            unreal.EditorLevelLibrary.new_level(ml_path)
-
-        seq_data = {
-            "sequence": seq,
-            "output": f"{seq.get_name()}",
-            "frame_range": (
-                seq.get_playback_start(),
-                seq.get_playback_end())}
+        pre_create_data["members"] = [sequence]
 
         self.create_instance(
             instance_data, product_name, pre_create_data,
-            seq.get_path_name(), seq.get_path_name(), ml_path, seq_data)
+            sequence, sequence, master_lvl, seq_data)
 
     def create_from_existing_sequence(
             self, product_name, instance_data, pre_create_data
     ):
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
+        sel_objects = send_request("get_selected_assets")
 
-        sel_objects = unreal.EditorUtilityLibrary.get_selected_assets()
-        selection = [
-            a.get_path_name() for a in sel_objects
-            if a.get_class().get_name() == "LevelSequence"]
+        if not sel_objects:
+            raise CreatorError("Please select at least one Level Sequence.")
 
-        if len(selection) == 0:
-            raise RuntimeError("Please select at least one Level Sequence.")
-
-        seq_data = None
-
-        for sel in selection:
-            selected_asset = ar.get_asset_by_object_path(sel).get_asset()
-            selected_asset_path = selected_asset.get_path_name()
-
-            # Check if the selected asset is a level sequence asset.
-            if selected_asset.get_class().get_name() != "LevelSequence":
-                unreal.log_warning(
-                    f"Skipping {selected_asset.get_name()}. It isn't a Level "
-                    "Sequence.")
-
-            if pre_create_data.get("use_hierarchy"):
-                # The asset name is the the third element of the path which
-                # contains the map.
-                # To take the asset name, we remove from the path the prefix
-                # "/Game/OpenPype/" and then we split the path by "/".
-                sel_path = selected_asset_path
-                asset_name = sel_path.replace(
-                    "/Game/Ayon/", "").split("/")[0]
-
-                search_path = f"/Game/Ayon/{asset_name}"
-            else:
-                search_path = Path(selected_asset_path).parent.as_posix()
-
-            # Get the master sequence and the master level.
-            # There should be only one sequence and one level in the directory.
-            try:
-                ar_filter = unreal.ARFilter(
-                    class_names=["LevelSequence"],
-                    package_paths=[search_path],
-                    recursive_paths=False)
-                sequences = ar.get_assets(ar_filter)
-                master_seq = sequences[0].get_asset().get_path_name()
-                master_seq_obj = sequences[0].get_asset()
-                ar_filter = unreal.ARFilter(
-                    class_names=["World"],
-                    package_paths=[search_path],
-                    recursive_paths=False)
-                levels = ar.get_assets(ar_filter)
-                master_lvl = levels[0].get_asset().get_path_name()
-            except IndexError:
-                raise RuntimeError(
-                    "Could not find the hierarchy for the selected sequence.")
-
-            # If the selected asset is the master sequence, we get its data
-            # and then we create the instance for the master sequence.
-            # Otherwise, we cycle from the master sequence to find the selected
-            # sequence and we get its data. This data will be used to create
-            # the instance for the selected sequence. In particular,
-            # we get the frame range of the selected sequence and its final
-            # output path.
-            master_seq_data = {
-                "sequence": master_seq_obj,
-                "output": f"{master_seq_obj.get_name()}",
-                "frame_range": (
-                    master_seq_obj.get_playback_start(),
-                    master_seq_obj.get_playback_end())}
-
-            if (selected_asset_path == master_seq or
-                    pre_create_data.get("use_hierarchy")):
-                seq_data = master_seq_data
-            else:
-                seq_data_list = [master_seq_data]
-
-                for seq in seq_data_list:
-                    subscenes = get_subsequences(seq.get('sequence'))
-
-                    for sub_seq in subscenes:
-                        sub_seq_obj = sub_seq.get_sequence()
-                        curr_data = {
-                            "sequence": sub_seq_obj,
-                            "output": (f"{seq.get('output')}/"
-                                       f"{sub_seq_obj.get_name()}"),
-                            "frame_range": (
-                                sub_seq.get_start_frame(),
-                                sub_seq.get_end_frame() - 1)}
-
-                        # If the selected asset is the current sub-sequence,
-                        # we get its data and we break the loop.
-                        # Otherwise, we add the current sub-sequence data to
-                        # the list of sequences to check.
-                        if sub_seq_obj.get_path_name() == selected_asset_path:
-                            seq_data = curr_data
-                            break
-
-                        seq_data_list.append(curr_data)
-
-                    # If we found the selected asset, we break the loop.
-                    if seq_data is not None:
-                        break
+        for selected_asset_path in sel_objects:
+            master_lvl, master_seq, seq_data = send_request(
+                "create_render_from_existing_sequence",
+                params={
+                    "selected_asset_path": selected_asset_path,
+                    "use_hierarchy": pre_create_data.get("use_hierarchy")
+                })
 
             # If we didn't find the selected asset, we don't create the
             # instance.
             if not seq_data:
-                unreal.log_warning(
-                    f"Skipping {selected_asset.get_name()}. It isn't a "
-                    "sub-sequence of the master sequence.")
+                message = (f"Skipping {selected_asset_path}. It isn't a "
+                           "sub-sequence of the master sequence.")
+                send_request(
+                    "log", params={"message": message, "level": "warning"})
+
                 continue
 
             self.create_instance(

--- a/client/ayon_unreal/plugins/create/create_uasset.py
+++ b/client/ayon_unreal/plugins/create/create_uasset.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from pathlib import Path
 
-import unreal
-
 from ayon_core.pipeline import CreatorError
+from ayon_unreal.api.pipeline import (
+    send_request,
+)
 from ayon_unreal.api.plugin import (
     UnrealAssetCreator,
 )
@@ -21,18 +22,15 @@ class CreateUAsset(UnrealAssetCreator):
 
     def create(self, product_name, instance_data, pre_create_data):
         if pre_create_data.get("use_selection"):
-            ar = unreal.AssetRegistryHelpers.get_asset_registry()
-
-            sel_objects = unreal.EditorUtilityLibrary.get_selected_assets()
-            selection = [a.get_path_name() for a in sel_objects]
+            selection = send_request("get_selected_assets")
 
             if len(selection) != 1:
                 raise CreatorError("Please select only one object.")
 
             obj = selection[0]
 
-            asset = ar.get_asset_by_object_path(obj).get_asset()
-            sys_path = unreal.SystemLibrary.get_system_path(asset)
+            sys_path = send_request(
+                "get_system_path", params={"asset_path": obj})
 
             if not sys_path:
                 raise CreatorError(

--- a/client/ayon_unreal/plugins/inventory/delete_unused_assets.py
+++ b/client/ayon_unreal/plugins/inventory/delete_unused_assets.py
@@ -1,8 +1,6 @@
-import unreal
-
-from ayon_unreal.api.tools_ui import qt_app_context
-from ayon_unreal.api.pipeline import delete_asset_if_unused
 from ayon_core.pipeline import InventoryAction
+from ayon_unreal.api.tools_ui import qt_app_context
+from ayon_unreal.api.pipeline import send_request
 
 
 class DeleteUnusedAssets(InventoryAction):
@@ -15,22 +13,6 @@ class DeleteUnusedAssets(InventoryAction):
     order = 1
 
     dialog = None
-
-    def _delete_unused_assets(self, containers):
-        allowed_families = ["model", "rig"]
-
-        for container in containers:
-            container_dir = container.get("namespace")
-            if container.get("family") not in allowed_families:
-                unreal.log_warning(
-                    f"Container {container_dir} is not supported.")
-                continue
-
-            asset_content = unreal.EditorAssetLibrary.list_assets(
-                container_dir, recursive=True, include_folder=False
-            )
-
-            delete_asset_if_unused(container, asset_content)
 
     def _show_confirmation_dialog(self, containers):
         from qtpy import QtCore
@@ -51,7 +33,9 @@ class DeleteUnusedAssets(InventoryAction):
         dialog.set_button_text("Delete")
 
         dialog.on_clicked.connect(
-            lambda: self._delete_unused_assets(containers)
+            lambda: send_request(
+                "delete_unused_assets", params={
+                    "containers": containers})
         )
 
         dialog.show()

--- a/client/ayon_unreal/plugins/inventory/update_actors.py
+++ b/client/ayon_unreal/plugins/inventory/update_actors.py
@@ -1,63 +1,5 @@
-import unreal
-
-from ayon_unreal.api.pipeline import (
-    ls,
-    replace_static_mesh_actors,
-    replace_skeletal_mesh_actors,
-    replace_geometry_cache_actors,
-)
 from ayon_core.pipeline import InventoryAction
-
-
-def update_assets(containers, selected):
-    allowed_families = ["model", "rig"]
-
-    # Get all the containers in the Unreal Project
-    all_containers = ls()
-
-    for container in containers:
-        container_dir = container.get("namespace")
-        if container.get("family") not in allowed_families:
-            unreal.log_warning(
-                f"Container {container_dir} is not supported.")
-            continue
-
-        # Get all containers with same asset_name but different objectName.
-        # These are the containers that need to be updated in the level.
-        sa_containers = [
-            i
-            for i in all_containers
-            if (
-                i.get("asset_name") == container.get("asset_name") and
-                i.get("objectName") != container.get("objectName")
-            )
-        ]
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            container_dir, recursive=True, include_folder=False
-        )
-
-        # Update all actors in level
-        for sa_cont in sa_containers:
-            sa_dir = sa_cont.get("namespace")
-            old_content = unreal.EditorAssetLibrary.list_assets(
-                sa_dir, recursive=True, include_folder=False
-            )
-
-            if container.get("family") == "rig":
-                replace_skeletal_mesh_actors(
-                    old_content, asset_content, selected)
-                replace_static_mesh_actors(
-                    old_content, asset_content, selected)
-            elif container.get("family") == "model":
-                if container.get("loader") == "PointCacheAlembicLoader":
-                    replace_geometry_cache_actors(
-                        old_content, asset_content, selected)
-                else:
-                    replace_static_mesh_actors(
-                        old_content, asset_content, selected)
-
-            unreal.EditorLevelLibrary.save_current_level()
+from ayon_unreal.api.pipeline import send_request
 
 
 class UpdateAllActors(InventoryAction):
@@ -69,7 +11,10 @@ class UpdateAllActors(InventoryAction):
     icon = "arrow-up"
 
     def process(self, containers):
-        update_assets(containers, False)
+        send_request(
+            "update_assets", params={
+                "containers": containers,
+                "selected": False})
 
 
 class UpdateSelectedActors(InventoryAction):
@@ -81,4 +26,7 @@ class UpdateSelectedActors(InventoryAction):
     icon = "arrow-up"
 
     def process(self, containers):
-        update_assets(containers, True)
+        send_request(
+            "update_assets", params={
+                "containers": containers,
+                "selected": True})

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -1,52 +1,59 @@
 # -*- coding: utf-8 -*-
 """Load Alembic Animation."""
-import os
 
 from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
 )
-from ayon_unreal.api import plugin
-from ayon_unreal.api import pipeline as unreal_pipeline
-import unreal  # noqa
+from ayon_unreal.api.plugin import UnrealBaseLoader
+from ayon_unreal.api.pipeline import (
+    send_request,
+    containerise,
+    AYON_ASSET_DIR,
+)
 
 
-class AnimationAlembicLoader(plugin.Loader):
+class AnimationAlembicLoader(UnrealBaseLoader):
     """Load Unreal SkeletalMesh from Alembic"""
 
     product_types = {"animation"}
     label = "Import Alembic Animation"
-    representations = {"abc"}
+    representations = ["abc"]
     icon = "cube"
     color = "orange"
 
-    def get_task(self, filename, asset_dir, asset_name, replace):
-        task = unreal.AssetImportTask()
-        options = unreal.AbcImportSettings()
-        sm_settings = unreal.AbcStaticMeshSettings()
-        conversion_settings = unreal.AbcConversionSettings(
-            preset=unreal.AbcConversionPreset.CUSTOM,
-            flip_u=False, flip_v=False,
-            rotation=[0.0, 0.0, 0.0],
-            scale=[1.0, 1.0, -1.0])
+    @staticmethod
+    def _import_abc_task(
+        filename, destination_path, destination_name, replace,
+        default_conversion
+    ):
+        conversion = (
+            None
+            if default_conversion
+            else {
+                "flip_u": False,
+                "flip_v": False,
+                "rotation": [0.0, 0.0, 0.0],
+                "scale": [1.0, 1.0, -1.0],
+            }
+        )
 
-        task.set_editor_property('filename', filename)
-        task.set_editor_property('destination_path', asset_dir)
-        task.set_editor_property('destination_name', asset_name)
-        task.set_editor_property('replace_existing', replace)
-        task.set_editor_property('automated', True)
-        task.set_editor_property('save', True)
+        params = {
+            "filename": filename,
+            "destination_path": destination_path,
+            "destination_name": destination_name,
+            "replace_existing": replace,
+            "automated": True,
+            "save": True,
+            "options_properties": [
+                ['import_type', 'unreal.AlembicImportType.SKELETAL']
+            ],
+            "conversion_settings": conversion
+        }
 
-        options.set_editor_property(
-            'import_type', unreal.AlembicImportType.SKELETAL)
+        send_request("import_abc_task", params=params)
 
-        options.static_mesh_settings = sm_settings
-        options.conversion_settings = conversion_settings
-        task.options = options
-
-        return task
-
-    def load(self, context, name, namespace, data):
+    def load(self, context, name=None, namespace=None, options=None):
         """Load and containerise representation into Content Browser.
 
         This is two step process. First, import FBX to temporary path and
@@ -61,48 +68,34 @@ class AnimationAlembicLoader(plugin.Loader):
                              This is not passed here, so namespace is set
                              by `containerise()` because only then we know
                              real path.
-            data (dict): Those would be data to be imprinted. This is not used
-                         now, data are imprinted by `containerise()`.
-
-        Returns:
-            list(str): list of container content
+            options (dict): Those would be data to be imprinted. This is not
+                            used now, data are imprinted by `containerise()`.
         """
 
         # Create directory for asset and ayon container
-        root = unreal_pipeline.AYON_ASSET_DIR
+        root = AYON_ASSET_DIR
         folder_name = context["folder"]["name"]
         folder_path = context["folder"]["path"]
         product_type = context["product"]["productType"]
-        suffix = "_CON"
-        if folder_name:
-            asset_name = "{}_{}".format(folder_name, name)
-        else:
-            asset_name = "{}".format(name)
+        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         version = context["version"]["version"]
-        # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{name}_hero"
-        else:
-            name_version = f"{name}_v{version:03d}"
 
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/{folder_name}/{name_version}", suffix="")
+        asset_dir, container_name = send_request(
+            "create_unique_asset_name", params={
+                "root": root,
+                "folder_name": folder_name,
+                "name": name,
+                "version": version})
 
-        container_name += suffix
+        default_conversion = options.get("default_conversion") or False
 
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            unreal.EditorAssetLibrary.make_directory(asset_dir)
+        if not send_request(
+                "does_directory_exist", params={"directory_path": asset_dir}):
+            send_request(
+                "make_directory", params={"directory_path": asset_dir})
 
-            path = self.filepath_from_context(context)
-            task = self.get_task(path, asset_dir, asset_name, False)
-
-            asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
-            asset_tools.import_asset_tasks([task])
-
-            # Create Asset Container
-            unreal_pipeline.create_container(
-                container=container_name, path=asset_dir)
+            self._import_abc_task(
+                self.fname, asset_dir, asset_name, False, default_conversion)
 
         data = {
             "schema": "ayon:container-2.0",
@@ -111,66 +104,33 @@ class AnimationAlembicLoader(plugin.Loader):
             "namespace": asset_dir,
             "container_name": container_name,
             "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": context["representation"]["id"],
-            "parent": context["representation"]["versionId"],
+            "loader": self.__class__.__name__,
+            "representation_id": str(context["representation"]["id"]),
+            "version_id": str(context["representation"]["versionId"]),
+            "default_conversion": default_conversion,
             "product_type": product_type,
             # TODO these should be probably removed
             "asset": folder_path,
             "family": product_type,
         }
-        unreal_pipeline.imprint(
-            f"{asset_dir}/{container_name}", data)
 
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=True
-        )
+        containerise(asset_dir, container_name, data)
 
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
-
-        return asset_content
+        return send_request(
+            "list_assets", params={
+                "directory_path": asset_dir,
+                "recursive": True,
+                "include_folder": True})
 
     def update(self, container, context):
-        folder_name = container["asset_name"]
         repre_entity = context["representation"]
-        source_path = get_representation_path(repre_entity)
-        destination_path = container["namespace"]
+        filename = get_representation_path(repre_entity)
+        asset_dir = container["namespace"]
+        asset_name = container["asset_name"]
 
-        task = self.get_task(
-            source_path, destination_path, folder_name, True
-        )
+        default_conversion = container["default_conversion"]
 
-        # do import fbx and replace existing data
-        asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
-        asset_tools.import_asset_tasks([task])
+        self._import_abc_task(
+            filename, asset_dir, asset_name, True, default_conversion)
 
-        container_path = f"{container['namespace']}/{container['objectName']}"
-
-        # update metadata
-        unreal_pipeline.imprint(
-            container_path,
-            {
-                "representation": repre_entity["id"],
-                "parent": repre_entity["versionId"],
-            })
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            destination_path, recursive=True, include_folder=True
-        )
-
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
-
-    def remove(self, container):
-        path = container["namespace"]
-        parent_path = os.path.dirname(path)
-
-        unreal.EditorAssetLibrary.delete_directory(path)
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            parent_path, recursive=False
-        )
-
-        if len(asset_content) == 0:
-            unreal.EditorAssetLibrary.delete_directory(parent_path)
+        super(UnrealBaseLoader, self).update(container, context)

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -1,23 +1,20 @@
 # -*- coding: utf-8 -*-
 """Load FBX with animations."""
-import os
 import json
-
-import unreal
-from unreal import EditorAssetLibrary
-from unreal import MovieSceneSkeletalAnimationTrack
-from unreal import MovieSceneSkeletalAnimationSection
 
 from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
 )
-from ayon_unreal.api import plugin
-from ayon_unreal.api import pipeline as unreal_pipeline
+from ayon_unreal.api.plugin import UnrealBaseLoader
+from ayon_unreal.api.pipeline import (
+    send_request,
+    containerise,
+)
 
 
-class AnimationFBXLoader(plugin.Loader):
+class AnimationFBXLoader(UnrealBaseLoader):
     """Load Unreal SkeletalMesh from FBX."""
 
     product_types = {"animation"}
@@ -26,98 +23,94 @@ class AnimationFBXLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    def _process(self, path, asset_dir, asset_name, instance_name):
+    @staticmethod
+    def _import_fbx_task(
+        filename, destination_path, destination_name, replace, automated,
+        skeleton
+    ):
+        folder_entity = get_current_folder_entity(fields=["attrib.fps"])
+        fps = folder_entity.get("attrib", {}).get("fps")
+
+        options_properties = [
+            ["automated_import_should_detect_type", "False"],
+            ["original_import_type",
+             "unreal.FBXImportType.FBXIT_SKELETAL_MESH"],
+            ["mesh_type_to_import",
+             "unreal.FBXImportType.FBXIT_ANIMATION"],
+            ["import_mesh", "False"],
+            ["import_animations", "True"],
+            ["override_full_name", "True"],
+            ["skeleton", f"get_asset({skeleton})"]
+        ]
+
+        sub_options_properties = [
+            ["anim_sequence_import_data", "animation_length",
+             "unreal.FBXAnimationLengthImportType.FBXALIT_EXPORTED_TIME"],
+            ["anim_sequence_import_data",
+             "import_meshes_in_bone_hierarchy", "False"],
+            ["anim_sequence_import_data", "use_default_sample_rate", "False"],
+            ["anim_sequence_import_data", "custom_sample_rate", str(fps)],
+            ["anim_sequence_import_data", "import_custom_attribute", "True"],
+            ["anim_sequence_import_data", "import_bone_tracks", "True"],
+            ["anim_sequence_import_data", "remove_redundant_keys", "False"],
+            ["anim_sequence_import_data", "convert_scene", "True"]
+        ]
+
+        params = {
+            "filename": filename,
+            "destination_path": destination_path,
+            "destination_name": destination_name,
+            "replace_existing": replace,
+            "automated": automated,
+            "save": True,
+            "options_properties": options_properties,
+            "sub_options_properties": sub_options_properties
+        }
+
+        send_request("import_fbx_task", params=params)
+
+    def _process(self, asset_dir, asset_name, instance_name):
         automated = False
         actor = None
-
-        task = unreal.AssetImportTask()
-        task.options = unreal.FbxImportUI()
+        skeleton = None
 
         if instance_name:
             automated = True
-            # Old method to get the actor
-            # actor_name = 'PersistentLevel.' + instance_name
-            # actor = unreal.EditorLevelLibrary.get_actor_reference(actor_name)
-            actors = unreal.EditorLevelLibrary.get_all_level_actors()
-            for a in actors:
-                if a.get_class().get_name() != "SkeletalMeshActor":
-                    continue
-                if a.get_actor_label() == instance_name:
-                    actor = a
-                    break
-            if not actor:
-                raise Exception(f"Could not find actor {instance_name}")
-            skeleton = actor.skeletal_mesh_component.skeletal_mesh.skeleton
-            task.options.set_editor_property('skeleton', skeleton)
+            actor, skeleton = send_request(
+                "get_actor_and_skeleton",
+                params={"instance_name": instance_name})
 
         if not actor:
             return None
 
-        folder_entity = get_current_folder_entity(fields=["attrib.fps"])
+        self._import_fbx_task(
+            self.fname, asset_dir, asset_name, False, automated,
+            skeleton)
 
-        task.set_editor_property('filename', path)
-        task.set_editor_property('destination_path', asset_dir)
-        task.set_editor_property('destination_name', asset_name)
-        task.set_editor_property('replace_existing', False)
-        task.set_editor_property('automated', automated)
-        task.set_editor_property('save', False)
-
-        # set import options here
-        task.options.set_editor_property(
-            'automated_import_should_detect_type', False)
-        task.options.set_editor_property(
-            'original_import_type', unreal.FBXImportType.FBXIT_SKELETAL_MESH)
-        task.options.set_editor_property(
-            'mesh_type_to_import', unreal.FBXImportType.FBXIT_ANIMATION)
-        task.options.set_editor_property('import_mesh', False)
-        task.options.set_editor_property('import_animations', True)
-        task.options.set_editor_property('override_full_name', True)
-
-        task.options.anim_sequence_import_data.set_editor_property(
-            'animation_length',
-            unreal.FBXAnimationLengthImportType.FBXALIT_EXPORTED_TIME
-        )
-        task.options.anim_sequence_import_data.set_editor_property(
-            'import_meshes_in_bone_hierarchy', False)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'use_default_sample_rate', False)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'custom_sample_rate', folder_entity.get("attrib", {}).get("fps"))
-        task.options.anim_sequence_import_data.set_editor_property(
-            'import_custom_attribute', True)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'import_bone_tracks', True)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'remove_redundant_keys', False)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'convert_scene', True)
-
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
-
-        asset_content = EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=True
-        )
+        asset_content = send_request(
+            "list_assets", params={
+                "directory_path": asset_dir,
+                "recursive": True,
+                "include_folder": True})
 
         animation = None
 
-        for a in asset_content:
-            imported_asset_data = EditorAssetLibrary.find_asset_data(a)
-            imported_asset = unreal.AssetRegistryHelpers.get_asset(
-                imported_asset_data)
-            if imported_asset.__class__ == unreal.AnimSequence:
-                animation = imported_asset
-                break
+        if animations := send_request(
+            "get_assets_of_class",
+            params={"asset_list": asset_content, "class_name": "AnimSequence"},
+        ):
+            animation = animations[0]
 
         if animation:
-            animation.set_editor_property('enable_root_motion', True)
-            actor.skeletal_mesh_component.set_editor_property(
-                'animation_mode', unreal.AnimationMode.ANIMATION_SINGLE_NODE)
-            actor.skeletal_mesh_component.animation_data.set_editor_property(
-                'anim_to_play', animation)
+            send_request(
+                "apply_animation_to_actor",
+                params={
+                    "actor_path": actor,
+                    "animation_path": animation})
 
         return animation
 
-    def load(self, context, name, namespace, options=None):
+    def load(self, context, name=None, namespace=None, options=None):
         """
         Load and containerise representation into Content Browser.
 
@@ -133,98 +126,81 @@ class AnimationFBXLoader(plugin.Loader):
                              This is not passed here, so namespace is set
                              by `containerise()` because only then we know
                              real path.
-            data (dict): Those would be data to be imprinted. This is not used
-                         now, data are imprinted by `containerise()`.
-
-        Returns:
-            list(str): list of container content
+            options (dict): Those would be data to be imprinted. This is not
+                            used now, data are imprinted by `containerise()`.
         """
         # Create directory for asset and Ayon container
-        root = "/Game/Ayon"
-        folder_path = context["folder"]["path"]
+        root = self.root
+        folder_entity = context["folder"]
+        folder_path = folder_entity["path"]
         hierarchy = folder_path.lstrip("/").split("/")
+
         folder_name = hierarchy.pop(-1)
-        product_type = context["product"]["productType"]
+        asset_name = f"{folder_name}_{name}" if folder_name else name
 
-        suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/Animations/{folder_name}/{name}", suffix="")
+        asset_dir, container_name = send_request(
+            "create_unique_asset_name", params={
+                "root": root,
+                "folder_name": folder_name,
+                "name": name})
 
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
-
-        _filter = unreal.ARFilter(
-            class_names=["World"],
-            package_paths=[f"{root}/{hierarchy[0]}"],
-            recursive_paths=False)
-        levels = ar.get_assets(_filter)
-        master_level = levels[0].get_asset().get_path_name()
+        master_level = send_request(
+            "get_first_asset_of_class",
+            params={
+                "class_name": "World",
+                "path": f"{root}/{hierarchy[0]}",
+                "recursive": False})
 
         hierarchy_dir = root
         for h in hierarchy:
             hierarchy_dir = f"{hierarchy_dir}/{h}"
         hierarchy_dir = f"{hierarchy_dir}/{folder_name}"
 
-        _filter = unreal.ARFilter(
-            class_names=["World"],
-            package_paths=[f"{hierarchy_dir}/"],
-            recursive_paths=True)
-        levels = ar.get_assets(_filter)
-        level = levels[0].get_asset().get_path_name()
+        level = send_request(
+            "get_first_asset_of_class",
+            params={
+                "class_name": "World",
+                "path": f"{hierarchy_dir}/",
+                "recursive": False})
 
-        unreal.EditorLevelLibrary.save_all_dirty_levels()
-        unreal.EditorLevelLibrary.load_level(level)
+        send_request("save_all_dirty_levels")
+        send_request("load_level", params={"level_path": level})
 
-        container_name += suffix
+        send_request("make_directory", params={"directory_path": asset_dir})
 
-        EditorAssetLibrary.make_directory(asset_dir)
-
-        path = self.filepath_from_context(context)
-        libpath = path.replace(".fbx", ".json")
+        libpath = self.fname.replace("fbx", "json")
 
         with open(libpath, "r") as fp:
             data = json.load(fp)
 
         instance_name = data.get("instance_name")
 
-        animation = self._process(path, asset_dir, asset_name, instance_name)
+        animation = self._process(asset_dir, asset_name, instance_name)
 
-        asset_content = EditorAssetLibrary.list_assets(
-            hierarchy_dir, recursive=True, include_folder=False)
+        asset_content = send_request(
+            "list_assets", params={
+                "directory_path": hierarchy_dir,
+                "recursive": True,
+                "include_folder": False})
 
         # Get the sequence for the layout, excluding the camera one.
-        sequences = [a for a in asset_content
-                     if (EditorAssetLibrary.find_asset_data(a).get_class() ==
-                         unreal.LevelSequence.static_class() and
-                         "_camera" not in a.split("/")[-1])]
+        all_sequences = send_request(
+            "get_assets_of_class",
+            params={
+                "asset_list": asset_content,
+                "class_name": "LevelSequence"})
+        sequences = [
+            a for a in all_sequences
+            if "_camera" not in a.split("/")[-1]]
 
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
+        send_request(
+            "apply_animation",
+            params={
+                "animation_path": animation,
+                "instance_name": instance_name,
+                "sequences": sequences})
 
-        for s in sequences:
-            sequence = ar.get_asset_by_object_path(s).get_asset()
-            possessables = [
-                p for p in sequence.get_possessables()
-                if p.get_display_name() == instance_name]
-
-            for p in possessables:
-                tracks = [
-                    t for t in p.get_tracks()
-                    if (t.get_class() ==
-                        MovieSceneSkeletalAnimationTrack.static_class())]
-
-                for t in tracks:
-                    sections = [
-                        s for s in t.get_sections()
-                        if (s.get_class() ==
-                            MovieSceneSkeletalAnimationSection.static_class())]
-
-                    for s in sections:
-                        s.params.set_editor_property('animation', animation)
-
-        # Create Asset Container
-        unreal_pipeline.create_container(
-            container=container_name, path=asset_dir)
+        product_type = context["product"]["productType"]
 
         data = {
             "schema": "ayon:container-2.0",
@@ -233,105 +209,38 @@ class AnimationFBXLoader(plugin.Loader):
             "container_name": container_name,
             "asset_name": asset_name,
             "loader": str(self.__class__.__name__),
-            "representation": context["representation"]["id"],
-            "parent": context["representation"]["versionId"],
+            "representation": str(context["representation"]["id"]),
+            "parent": str(context["representation"]["versionId"]),
             "folder_path": folder_path,
             "product_type": product_type,
             # TODO these shold be probably removed
             "asset": folder_path,
             "family": product_type
         }
-        unreal_pipeline.imprint(f"{asset_dir}/{container_name}", data)
+        containerise(asset_dir, container_name, data)
 
-        imported_content = EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=False)
+        send_request("save_current_level")
+        send_request("load_level", params={"level_path": master_level})
 
-        for a in imported_content:
-            EditorAssetLibrary.save_asset(a)
-
-        unreal.EditorLevelLibrary.save_current_level()
-        unreal.EditorLevelLibrary.load_level(master_level)
+        return send_request(
+            "list_assets", params={
+                "directory_path": asset_dir,
+                "recursive": True,
+                "include_folder": True})
 
     def update(self, container, context):
+        asset_dir = container.get('namespace')
         repre_entity = context["representation"]
-        folder_name = container["asset_name"]
-        source_path = get_representation_path(repre_entity)
-        folder_entity = get_current_folder_entity(fields=["attrib.fps"])
-        destination_path = container["namespace"]
+        asset_name = container["asset_name"]
 
-        task = unreal.AssetImportTask()
-        task.options = unreal.FbxImportUI()
+        filename = get_representation_path(repre_entity)
 
-        task.set_editor_property('filename', source_path)
-        task.set_editor_property('destination_path', destination_path)
-        # strip suffix
-        task.set_editor_property('destination_name', folder_name)
-        task.set_editor_property('replace_existing', True)
-        task.set_editor_property('automated', True)
-        task.set_editor_property('save', True)
+        skeleton = send_request(
+            "get_skeleton_from_skeletal_mesh",
+            params={
+                "skeletal_mesh_path": f"{asset_dir}/{asset_name}"})
 
-        # set import options here
-        task.options.set_editor_property(
-            'automated_import_should_detect_type', False)
-        task.options.set_editor_property(
-            'original_import_type', unreal.FBXImportType.FBXIT_SKELETAL_MESH)
-        task.options.set_editor_property(
-            'mesh_type_to_import', unreal.FBXImportType.FBXIT_ANIMATION)
-        task.options.set_editor_property('import_mesh', False)
-        task.options.set_editor_property('import_animations', True)
-        task.options.set_editor_property('override_full_name', True)
+        self._import_fbx_task(
+            filename, asset_dir, asset_name, True, True, skeleton)
 
-        task.options.anim_sequence_import_data.set_editor_property(
-            'animation_length',
-            unreal.FBXAnimationLengthImportType.FBXALIT_EXPORTED_TIME
-        )
-        task.options.anim_sequence_import_data.set_editor_property(
-            'import_meshes_in_bone_hierarchy', False)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'use_default_sample_rate', False)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'custom_sample_rate', folder_entity.get("attrib", {}).get("fps"))
-        task.options.anim_sequence_import_data.set_editor_property(
-            'import_custom_attribute', True)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'import_bone_tracks', True)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'remove_redundant_keys', False)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'convert_scene', True)
-
-        skeletal_mesh = EditorAssetLibrary.load_asset(
-            container.get('namespace') + "/" + container.get('asset_name'))
-        skeleton = skeletal_mesh.get_editor_property('skeleton')
-        task.options.set_editor_property('skeleton', skeleton)
-
-        # do import fbx and replace existing data
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
-        container_path = f'{container["namespace"]}/{container["objectName"]}'
-        # update metadata
-        unreal_pipeline.imprint(
-            container_path,
-            {
-                "representation": repre_entity["id"],
-                "parent": repre_entity["versionId"],
-            })
-
-        asset_content = EditorAssetLibrary.list_assets(
-            destination_path, recursive=True, include_folder=True
-        )
-
-        for a in asset_content:
-            EditorAssetLibrary.save_asset(a)
-
-    def remove(self, container):
-        path = container["namespace"]
-        parent_path = os.path.dirname(path)
-
-        EditorAssetLibrary.delete_directory(path)
-
-        asset_content = EditorAssetLibrary.list_assets(
-            parent_path, recursive=False, include_folder=True
-        )
-
-        if len(asset_content) == 0:
-            EditorAssetLibrary.delete_directory(parent_path)
+        super(UnrealBaseLoader, self).update(container, repre_entity)

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -2,30 +2,24 @@
 """Load camera from FBX."""
 from pathlib import Path
 
-import ayon_api
-
-import unreal
-from unreal import (
-    EditorAssetLibrary,
-    EditorLevelLibrary,
-    EditorLevelUtils,
-    LevelSequenceEditorBlueprintLibrary as LevelSequenceLib,
+from ayon_api import (
+    get_folder_by_name,
+    get_folder_by_path,
+    get_folders,
 )
 from ayon_core.pipeline import (
     AYON_CONTAINER_ID,
     get_current_project_name,
     get_representation_path,
 )
-from ayon_unreal.api import plugin
+from ayon_unreal.api.plugin import UnrealBaseLoader
 from ayon_unreal.api.pipeline import (
-    generate_sequence,
-    set_sequence_hierarchy,
-    create_container,
-    imprint,
+    send_request,
+    containerise,
 )
 
 
-class CameraLoader(plugin.Loader):
+class CameraLoader(UnrealBaseLoader):
     """Load Unreal StaticMesh from FBX"""
 
     product_types = {"camera"}
@@ -34,34 +28,106 @@ class CameraLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    def _import_camera(
-        self, world, sequence, bindings, import_fbx_settings, import_filename
+    @staticmethod
+    def _create_levels(
+        hierarchy_dir_list, hierarchy, asset_dir, asset
     ):
-        ue_version = unreal.SystemLibrary.get_engine_version().split('.')
-        ue_major = int(ue_version[0])
-        ue_minor = int(ue_version[1])
+        # Create map for the shot, and create hierarchy of map. If the maps
+        # already exist, we will use them.
+        h_dir = hierarchy_dir_list[0]
+        h_asset = hierarchy[0]
+        master_level = f"{h_dir}/{h_asset}_map.{h_asset}_map"
+        if not send_request(
+                "does_asset_exist", params={"asset_path": master_level}):
+            send_request(
+                "new_level",
+                params={"level_path": f"{h_dir}/{h_asset}_map"})
 
-        if ue_major == 4 and ue_minor <= 26:
-            unreal.SequencerTools.import_fbx(
-                world,
-                sequence,
-                bindings,
-                import_fbx_settings,
-                import_filename
-            )
-        elif (ue_major == 4 and ue_minor >= 27) or ue_major == 5:
-            unreal.SequencerTools.import_level_sequence_fbx(
-                world,
-                sequence,
-                bindings,
-                import_fbx_settings,
-                import_filename
-            )
-        else:
-            raise NotImplementedError(
-                f"Unreal version {ue_major} not supported")
+        level = f"{asset_dir}/{asset}_map_camera.{asset}_map_camera"
+        if not send_request(
+                "does_asset_exist", params={"asset_path": level}):
+            send_request(
+                "new_level",
+                params={"level_path": f"{asset_dir}/{asset}_map_camera"})
 
-    def load(self, context, name, namespace, data):
+            send_request("load_level", params={"level_path": master_level})
+            send_request("add_level_to_world", params={"level_path": level})
+
+        send_request("save_all_dirty_levels")
+        send_request("load_level", params={"level_path": level})
+
+        return master_level, level
+
+    @staticmethod
+    def _get_frame_info(h_dir):
+        project_name = get_current_project_name()
+        asset_data = get_folder_by_name(
+            project_name,
+            h_dir.split('/')[-1],
+            fields=["_id", "data.fps"]
+        )
+
+        start_frames = []
+        end_frames = []
+
+        elements = list(get_folders(
+            project_name,
+            parent_ids=[asset_data["_id"]],
+            fields=["_id", "data.clipIn", "data.clipOut"]
+        ))
+        for e in elements:
+            start_frames.append(e.get('data').get('clipIn'))
+            end_frames.append(e.get('data').get('clipOut'))
+
+            elements.extend(get_folders(
+                project_name,
+                parent_ids=[e["_id"]],
+                fields=["_id", "data.clipIn", "data.clipOut"]
+            ))
+
+        min_frame = min(start_frames)
+        max_frame = max(end_frames)
+
+        return min_frame, max_frame, asset_data.get('data').get("fps")
+
+    def _get_sequences(self, hierarchy_dir_list, hierarchy):
+        frame_ranges = []
+        sequences = []
+        for (h_dir, h) in zip(hierarchy_dir_list, hierarchy):
+            root_content = send_request(
+                "list_assets", params={
+                    "directory_path": h_dir,
+                    "recursive": False,
+                    "include_folder": False})
+
+            if existing_sequences := send_request(
+                "get_assets_of_class",
+                params={
+                    "asset_list": root_content, "class_name": "LevelSequence"},
+            ):
+                for sequence in existing_sequences:
+                    sequences.append(sequence)
+                    frame_ranges.append(
+                        send_request(
+                            "get_sequence_frame_range",
+                            params={"sequence_path": sequence}))
+            else:
+                start_frame, end_frame, fps = self._get_frame_info(h_dir)
+                sequence = send_request(
+                    "generate_sequence",
+                    params={
+                        "asset_name": h,
+                        "asset_path": h_dir,
+                        "start_frame": start_frame,
+                        "end_frame": end_frame,
+                        "fps": fps})
+
+                sequences.append(sequence)
+                frame_ranges.append((start_frame, end_frame))
+
+        return sequences, frame_ranges
+
+    def load(self, context, name=None, namespace=None, options=None):
         """
         Load and containerise representation into Content Browser.
 
@@ -77,14 +143,10 @@ class CameraLoader(plugin.Loader):
                              This is not passed here, so namespace is set
                              by `containerise()` because only then we know
                              real path.
-            data (dict): Those would be data to be imprinted. This is not used
-                         now, data are imprinted by `containerise()`.
-
-        Returns:
-            list(str): list of container content
+            options (dict): Those would be data to be imprinted. This is not
+                            used now, data are imprinted by `containerise()`.
         """
-
-        # Create directory for asset and Ayon container
+        # Create directory for asset and OpenPype container
         folder_entity = context["folder"]
         folder_attributes = folder_entity["attrib"]
         folder_path = folder_entity["path"]
@@ -94,158 +156,78 @@ class CameraLoader(plugin.Loader):
         # Pop folder name
         folder_name = hierarchy_parts.pop(-1)
 
-        root = "/Game/Ayon"
+        root = self.root
+        asset_name = f"{folder_name}_{name}" if folder_name else name
+
         hierarchy_dir = root
         hierarchy_dir_list = []
         for h in hierarchy_parts:
             hierarchy_dir = f"{hierarchy_dir}/{h}"
             hierarchy_dir_list.append(hierarchy_dir)
-        suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else name
-
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
 
         # Create a unique name for the camera directory
         unique_number = 1
-        if EditorAssetLibrary.does_directory_exist(
-            f"{hierarchy_dir}/{folder_name}"
-        ):
-            asset_content = EditorAssetLibrary.list_assets(
-                f"{root}/{folder_name}", recursive=False, include_folder=True
-            )
+        if send_request(
+                "does_directory_exist",
+                params={"directory_path": f"{hierarchy_dir}/{folder_name}"}):
+            asset_content = send_request(
+                "list_assets", params={
+                    "directory_path": f"{root}/{folder_name}",
+                    "recursive": False,
+                    "include_folder": True})
 
             # Get highest number to make a unique name
             folders = [a for a in asset_content
                        if a[-1] == "/" and f"{name}_" in a]
-            # Get number from folder name. Splits the string by "_" and
-            # removes the last element (which is a "/").
             f_numbers = [int(f.split("_")[-1][:-1]) for f in folders]
             f_numbers.sort()
             unique_number = f_numbers[-1] + 1 if f_numbers else 1
 
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{hierarchy_dir}/{folder_name}/{name}_{unique_number:02d}", suffix="")
+        asset_dir, container_name = send_request(
+            "create_unique_asset_name", params={
+                "root": hierarchy_dir,
+                "folder_name": folder_name,
+                "name": name,
+                "version": {"name": unique_number}})
 
-        container_name += suffix
+        send_request("make_directory", params={"directory_path": asset_dir})
 
-        EditorAssetLibrary.make_directory(asset_dir)
+        master_level, level = self._create_levels(
+            hierarchy_dir_list, hierarchy_parts, asset_dir, folder_name)
 
-        # Create map for the shot, and create hierarchy of map. If the maps
-        # already exist, we will use them.
-        h_dir = hierarchy_dir_list[0]
-        h_asset = hierarchy_dir[0]
-        master_level = f"{h_dir}/{h_asset}_map.{h_asset}_map"
-        if not EditorAssetLibrary.does_asset_exist(master_level):
-            EditorLevelLibrary.new_level(f"{h_dir}/{h_asset}_map")
+        sequences, frame_ranges = self._get_sequences(
+            hierarchy_dir_list, hierarchy_parts)
 
-        level = (
-            f"{asset_dir}/{folder_name}_map_camera.{folder_name}_map_camera"
-        )
-        if not EditorAssetLibrary.does_asset_exist(level):
-            EditorLevelLibrary.new_level(
-                f"{asset_dir}/{folder_name}_map_camera"
-            )
-
-            EditorLevelLibrary.load_level(master_level)
-            EditorLevelUtils.add_level_to_world(
-                EditorLevelLibrary.get_editor_world(),
-                level,
-                unreal.LevelStreamingDynamic
-            )
-        EditorLevelLibrary.save_all_dirty_levels()
-        EditorLevelLibrary.load_level(level)
-
-        # Get all the sequences in the hierarchy. It will create them, if
-        # they don't exist.
-        frame_ranges = []
-        sequences = []
-        for (h_dir, h) in zip(hierarchy_dir_list, hierarchy_parts):
-            root_content = EditorAssetLibrary.list_assets(
-                h_dir, recursive=False, include_folder=False)
-
-            existing_sequences = [
-                EditorAssetLibrary.find_asset_data(asset)
-                for asset in root_content
-                if EditorAssetLibrary.find_asset_data(
-                    asset).get_class().get_name() == 'LevelSequence'
-            ]
-
-            if existing_sequences:
-                for seq in existing_sequences:
-                    sequences.append(seq.get_asset())
-                    frame_ranges.append((
-                        seq.get_asset().get_playback_start(),
-                        seq.get_asset().get_playback_end()))
-            else:
-                sequence, frame_range = generate_sequence(h, h_dir)
-
-                sequences.append(sequence)
-                frame_ranges.append(frame_range)
-
-        EditorAssetLibrary.make_directory(asset_dir)
-
-        cam_seq = tools.create_asset(
-            asset_name=f"{folder_name}_camera",
-            package_path=asset_dir,
-            asset_class=unreal.LevelSequence,
-            factory=unreal.LevelSequenceFactoryNew()
-        )
-
-        # Add sequences data to hierarchy
-        for i in range(len(sequences) - 1):
-            set_sequence_hierarchy(
-                sequences[i], sequences[i + 1],
-                frame_ranges[i][1],
-                frame_ranges[i + 1][0], frame_ranges[i + 1][1],
-                [level])
-
+        fps = folder_attributes.get("fps")
         clip_in = folder_attributes.get("clipIn")
         clip_out = folder_attributes.get("clipOut")
+        frame_start = folder_attributes.get('frameStart')
 
-        cam_seq.set_display_rate(
-            unreal.FrameRate(folder_attributes.get("fps"), 1.0))
-        cam_seq.set_playback_start(clip_in)
-        cam_seq.set_playback_end(clip_out + 1)
-        set_sequence_hierarchy(
-            sequences[-1], cam_seq,
-            frame_ranges[-1][1],
-            clip_in, clip_out,
-            [level])
+        cam_sequence = send_request(
+            "generate_camera_sequence",
+            params={
+                "folder_name": folder_name,
+                "asset_dir": asset_dir,
+                "sequences": sequences,
+                "frame_ranges": frame_ranges,
+                "level": level,
+                "fps": fps,
+                "clip_in": clip_in,
+                "clip_out": clip_out})
 
-        settings = unreal.MovieSceneUserImportFBXSettings()
-        settings.set_editor_property('reduce_keys', False)
+        send_request(
+            "import_camera",
+            params={
+                "sequence_path": cam_sequence,
+                "import_filename": self.filepath_from_context(context)})
 
-        if cam_seq:
-            path = self.filepath_from_context(context)
-            self._import_camera(
-                EditorLevelLibrary.get_editor_world(),
-                cam_seq,
-                cam_seq.get_bindings(),
-                settings,
-                path
-            )
-
-        # Set range of all sections
-        # Changing the range of the section is not enough. We need to change
-        # the frame of all the keys in the section.
-        for possessable in cam_seq.get_possessables():
-            for tracks in possessable.get_tracks():
-                for section in tracks.get_sections():
-                    section.set_range(clip_in, clip_out + 1)
-                    for channel in section.get_all_channels():
-                        for key in channel.get_keys():
-                            old_time = key.get_time().get_editor_property(
-                                'frame_number')
-                            old_time_value = old_time.get_editor_property(
-                                'value')
-                            new_time = old_time_value + (
-                                clip_in - folder_attributes.get('frameStart')
-                            )
-                            key.set_time(unreal.FrameNumber(value=new_time))
-
-        # Create Asset Container
-        create_container(
-            container=container_name, path=asset_dir)
+        send_request(
+            "set_sequences_range",
+            params={
+                "sequence": cam_sequence,
+                "clip_in": clip_in,
+                "clip_out": clip_out,
+                "frame_start": frame_start})
 
         product_type = context["product"]["productType"]
         data = {
@@ -256,336 +238,103 @@ class CameraLoader(plugin.Loader):
             "container_name": container_name,
             "asset_name": asset_name,
             "loader": str(self.__class__.__name__),
-            "representation": context["representation"]["id"],
-            "parent": context["representation"]["versionId"],
+            "representation": str(context["representation"]["id"]),
+            "parent": str(context["representation"]["versionId"]),
             "product_type": product_type,
             # TODO these should be probably removed
             "asset": folder_name,
             "family": product_type,
         }
-        imprint(f"{asset_dir}/{container_name}", data)
 
-        EditorLevelLibrary.save_all_dirty_levels()
-        EditorLevelLibrary.load_level(master_level)
+        containerise(asset_dir, container_name, data)
 
-        # Save all assets in the hierarchy
-        asset_content = EditorAssetLibrary.list_assets(
-            hierarchy_dir_list[0], recursive=True, include_folder=False
-        )
+        send_request("save_all_dirty_levels")
+        send_request("load_level", params={"level_path": master_level})
 
-        for a in asset_content:
-            EditorAssetLibrary.save_asset(a)
+        assets = send_request(
+            "list_assets", params={
+                "directory_path": hierarchy_dir_list[0],
+                "recursive": True,
+                "include_folder": False})
 
-        return asset_content
+        send_request("save_listed_assets", params={"asset_list": assets})
+
+        return assets
 
     def update(self, container, context):
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
-
-        curr_level_sequence = LevelSequenceLib.get_current_level_sequence()
-        curr_time = LevelSequenceLib.get_current_time()
-        is_cam_lock = LevelSequenceLib.is_camera_cut_locked_to_viewport()
-
-        editor_subsystem = unreal.UnrealEditorSubsystem()
-        vp_loc, vp_rot = editor_subsystem.get_level_viewport_camera_info()
-
-        asset_dir = container.get('namespace')
-
-        EditorLevelLibrary.save_current_level()
-
-        _filter = unreal.ARFilter(
-            class_names=["LevelSequence"],
-            package_paths=[asset_dir],
-            recursive_paths=False)
-        sequences = ar.get_assets(_filter)
-        _filter = unreal.ARFilter(
-            class_names=["World"],
-            package_paths=[asset_dir],
-            recursive_paths=True)
-        maps = ar.get_assets(_filter)
-
-        # There should be only one map in the list
-        EditorLevelLibrary.load_level(maps[0].get_asset().get_path_name())
-
-        level_sequence = sequences[0].get_asset()
-
-        display_rate = level_sequence.get_display_rate()
-        playback_start = level_sequence.get_playback_start()
-        playback_end = level_sequence.get_playback_end()
-
-        sequence_name = f"{container.get('asset')}_camera"
-
-        # Get the actors in the level sequence.
-        objs = unreal.SequencerTools.get_bound_objects(
-            unreal.EditorLevelLibrary.get_editor_world(),
-            level_sequence,
-            level_sequence.get_bindings(),
-            unreal.SequencerScriptingRange(
-                has_start_value=True,
-                has_end_value=True,
-                inclusive_start=level_sequence.get_playback_start(),
-                exclusive_end=level_sequence.get_playback_end()
-            )
-        )
-
-        # Delete actors from the map
-        for o in objs:
-            if o.bound_objects[0].get_class().get_name() == "CineCameraActor":
-                actor_path = o.bound_objects[0].get_path_name().split(":")[-1]
-                actor = EditorLevelLibrary.get_actor_reference(actor_path)
-                EditorLevelLibrary.destroy_actor(actor)
-
-        # Remove the Level Sequence from the parent.
-        # We need to traverse the hierarchy from the master sequence to find
-        # the level sequence.
-        root = "/Game/Ayon"
-        namespace = container.get('namespace').replace(f"{root}/", "")
-        ms_asset = namespace.split('/')[0]
-        _filter = unreal.ARFilter(
-            class_names=["LevelSequence"],
-            package_paths=[f"{root}/{ms_asset}"],
-            recursive_paths=False)
-        sequences = ar.get_assets(_filter)
-        master_sequence = sequences[0].get_asset()
-        _filter = unreal.ARFilter(
-            class_names=["World"],
-            package_paths=[f"{root}/{ms_asset}"],
-            recursive_paths=False)
-        levels = ar.get_assets(_filter)
-        master_level = levels[0].get_asset().get_path_name()
-
-        sequences = [master_sequence]
-
-        parent = None
-        sub_scene = None
-        for s in sequences:
-            tracks = s.get_master_tracks()
-            subscene_track = None
-            for t in tracks:
-                if t.get_class() == unreal.MovieSceneSubTrack.static_class():
-                    subscene_track = t
-            if subscene_track:
-                sections = subscene_track.get_sections()
-                for ss in sections:
-                    if ss.get_sequence().get_name() == sequence_name:
-                        parent = s
-                        sub_scene = ss
-                        break
-                    sequences.append(ss.get_sequence())
-                for i, ss in enumerate(sections):
-                    ss.set_row_index(i)
-            if parent:
-                break
-
-            assert parent, "Could not find the parent sequence"
-
-        EditorAssetLibrary.delete_asset(level_sequence.get_path_name())
-
-        settings = unreal.MovieSceneUserImportFBXSettings()
-        settings.set_editor_property('reduce_keys', False)
-
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        new_sequence = tools.create_asset(
-            asset_name=sequence_name,
-            package_path=asset_dir,
-            asset_class=unreal.LevelSequence,
-            factory=unreal.LevelSequenceFactoryNew()
-        )
-
-        new_sequence.set_display_rate(display_rate)
-        new_sequence.set_playback_start(playback_start)
-        new_sequence.set_playback_end(playback_end)
-
-        sub_scene.set_sequence(new_sequence)
-
         repre_entity = context["representation"]
         repre_path = get_representation_path(repre_entity)
-        self._import_camera(
-            EditorLevelLibrary.get_editor_world(),
-            new_sequence,
-            new_sequence.get_bindings(),
-            settings,
-            repre_path
-        )
 
-        # Set range of all sections
-        # Changing the range of the section is not enough. We need to change
-        # the frame of all the keys in the section.
+        sequence_path, curr_time, is_cam_lock, vp_loc, vp_rot = send_request(
+            "get_current_sequence_and_level_info")
+
+        new_sequence = send_request(
+            "update_camera",
+            params={
+                "asset_dir": container.get('namespace'),
+                "asset": container.get('asset'),
+                "root": self.root})
+
+        send_request(
+            "import_camera",
+            params={
+                "sequence_path": new_sequence,
+                "import_filename": repre_path})
+
         project_name = get_current_project_name()
         folder_path = container.get("folder_path")
         if folder_path is None:
             folder_path = container.get("asset")
-        folder_entity = ayon_api.get_folder_by_path(project_name, folder_path)
+        folder_entity = get_folder_by_path(project_name, folder_path)
         folder_attributes = folder_entity["attrib"]
 
         clip_in = folder_attributes["clipIn"]
         clip_out = folder_attributes["clipOut"]
         frame_start = folder_attributes["frameStart"]
-        for possessable in new_sequence.get_possessables():
-            for tracks in possessable.get_tracks():
-                for section in tracks.get_sections():
-                    section.set_range(clip_in, clip_out + 1)
-                    for channel in section.get_all_channels():
-                        for key in channel.get_keys():
-                            old_time = key.get_time().get_editor_property(
-                                'frame_number')
-                            old_time_value = old_time.get_editor_property(
-                                'value')
-                            new_time = old_time_value + (
-                                clip_in - frame_start
-                            )
-                            key.set_time(unreal.FrameNumber(value=new_time))
 
-        data = {
-            "representation": repre_entity["id"],
-            "parent": repre_entity["versionId"],
-        }
-        imprint(f"{asset_dir}/{container.get('container_name')}", data)
+        send_request(
+            "set_sequences_range",
+            params={
+                "sequence": new_sequence,
+                "clip_in": clip_in,
+                "clip_out": clip_out,
+                "frame_start": frame_start})
 
-        EditorLevelLibrary.save_current_level()
+        super(CameraLoader, self).update(container, context)
 
-        asset_content = EditorAssetLibrary.list_assets(
-            f"{root}/{ms_asset}", recursive=True, include_folder=False)
+        send_request("save_all_dirty_levels")
 
-        for a in asset_content:
-            EditorAssetLibrary.save_asset(a)
+        namespace = container.get('namespace').replace(f"{self.root}/", "")
+        ms_asset = namespace.split('/')[0]
+        asset_path = f"{self.root}/{ms_asset}"
 
-        EditorLevelLibrary.load_level(master_level)
+        assets = send_request(
+            "list_assets", params={
+                "directory_path": asset_path,
+                "recursive": True,
+                "include_folder": False})
 
-        if curr_level_sequence:
-            LevelSequenceLib.open_level_sequence(curr_level_sequence)
-            LevelSequenceLib.set_current_time(curr_time)
-            LevelSequenceLib.set_lock_camera_cut_to_viewport(is_cam_lock)
+        send_request("save_listed_assets", params={"asset_list": assets})
 
-        editor_subsystem.set_level_viewport_camera_info(vp_loc, vp_rot)
+        send_request(
+            "get_and_load_master_level", params={"path": asset_path})
+
+        send_request(
+            "set_current_sequence_and_level_info",
+            params={
+                "sequence_path": sequence_path,
+                "curr_time": curr_time,
+                "is_cam_lock": is_cam_lock,
+                "vp_loc": vp_loc,
+                "vp_rot": vp_rot})
 
     def remove(self, container):
-        asset_dir = container.get('namespace')
-        path = Path(asset_dir)
+        root = self.root
+        path = container["namespace"]
+        asset = container.get('asset')
 
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
-        _filter = unreal.ARFilter(
-            class_names=["LevelSequence"],
-            package_paths=[asset_dir],
-            recursive_paths=False)
-        sequences = ar.get_assets(_filter)
+        send_request(
+            "remove_camera", params={
+                "asset_dir": path, "asset": asset, "root": root})
 
-        if not sequences:
-            raise Exception("Could not find sequence.")
-
-        world = ar.get_asset_by_object_path(
-            EditorLevelLibrary.get_editor_world().get_path_name())
-
-        _filter = unreal.ARFilter(
-            class_names=["World"],
-            package_paths=[asset_dir],
-            recursive_paths=True)
-        maps = ar.get_assets(_filter)
-
-        # There should be only one map in the list
-        if not maps:
-            raise Exception("Could not find map.")
-
-        map = maps[0]
-
-        EditorLevelLibrary.save_all_dirty_levels()
-        EditorLevelLibrary.load_level(map.get_asset().get_path_name())
-
-        # Remove the camera from the level.
-        actors = EditorLevelLibrary.get_all_level_actors()
-
-        for a in actors:
-            if a.__class__ == unreal.CineCameraActor:
-                EditorLevelLibrary.destroy_actor(a)
-
-        EditorLevelLibrary.save_all_dirty_levels()
-        EditorLevelLibrary.load_level(world.get_asset().get_path_name())
-
-        # There should be only one sequence in the path.
-        sequence_name = sequences[0].asset_name
-
-        # Remove the Level Sequence from the parent.
-        # We need to traverse the hierarchy from the master sequence to find
-        # the level sequence.
-        root = "/Game/Ayon"
-        namespace = container.get('namespace').replace(f"{root}/", "")
-        ms_asset = namespace.split('/')[0]
-        _filter = unreal.ARFilter(
-            class_names=["LevelSequence"],
-            package_paths=[f"{root}/{ms_asset}"],
-            recursive_paths=False)
-        sequences = ar.get_assets(_filter)
-        master_sequence = sequences[0].get_asset()
-        _filter = unreal.ARFilter(
-            class_names=["World"],
-            package_paths=[f"{root}/{ms_asset}"],
-            recursive_paths=False)
-        levels = ar.get_assets(_filter)
-        master_level = levels[0].get_full_name()
-
-        sequences = [master_sequence]
-
-        parent = None
-        for s in sequences:
-            tracks = s.get_master_tracks()
-            subscene_track = None
-            visibility_track = None
-            for t in tracks:
-                if t.get_class() == unreal.MovieSceneSubTrack.static_class():
-                    subscene_track = t
-                if (t.get_class() ==
-                        unreal.MovieSceneLevelVisibilityTrack.static_class()):
-                    visibility_track = t
-            if subscene_track:
-                sections = subscene_track.get_sections()
-                for ss in sections:
-                    if ss.get_sequence().get_name() == sequence_name:
-                        parent = s
-                        subscene_track.remove_section(ss)
-                        break
-                    sequences.append(ss.get_sequence())
-                # Update subscenes indexes.
-                for i, ss in enumerate(sections):
-                    ss.set_row_index(i)
-
-            if visibility_track:
-                sections = visibility_track.get_sections()
-                for ss in sections:
-                    if (unreal.Name(f"{container.get('asset')}_map_camera")
-                            in ss.get_level_names()):
-                        visibility_track.remove_section(ss)
-                # Update visibility sections indexes.
-                i = -1
-                prev_name = []
-                for ss in sections:
-                    if prev_name != ss.get_level_names():
-                        i += 1
-                    ss.set_row_index(i)
-                    prev_name = ss.get_level_names()
-            if parent:
-                break
-
-        assert parent, "Could not find the parent sequence"
-
-        # Create a temporary level to delete the layout level.
-        EditorLevelLibrary.save_all_dirty_levels()
-        EditorAssetLibrary.make_directory(f"{root}/tmp")
-        tmp_level = f"{root}/tmp/temp_map"
-        if not EditorAssetLibrary.does_asset_exist(f"{tmp_level}.temp_map"):
-            EditorLevelLibrary.new_level(tmp_level)
-        else:
-            EditorLevelLibrary.load_level(tmp_level)
-
-        # Delete the layout directory.
-        EditorAssetLibrary.delete_directory(asset_dir)
-
-        EditorLevelLibrary.load_level(master_level)
-        EditorAssetLibrary.delete_directory(f"{root}/tmp")
-
-        # Check if there isn't any more assets in the parent folder, and
-        # delete it if not.
-        asset_content = EditorAssetLibrary.list_assets(
-            path.parent.as_posix(), recursive=False, include_folder=True
-        )
-
-        if len(asset_content) == 0:
-            EditorAssetLibrary.delete_directory(path.parent.as_posix())
+        super(CameraLoader, self).remove(container)

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -1,22 +1,19 @@
 # -*- coding: utf-8 -*-
 """Loader for published alembics."""
-import os
 
 from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
 )
-from ayon_unreal.api import plugin
+from ayon_unreal.api.plugin import UnrealBaseLoader
 from ayon_unreal.api.pipeline import (
+    send_request,
+    containerise,
     AYON_ASSET_DIR,
-    create_container,
-    imprint,
 )
 
-import unreal  # noqa
 
-
-class PointCacheAlembicLoader(plugin.Loader):
+class PointCacheAlembicLoader(UnrealBaseLoader):
     """Load Point Cache from Alembic"""
 
     product_types = {"model", "pointcache"}
@@ -25,95 +22,43 @@ class PointCacheAlembicLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    root = AYON_ASSET_DIR
-
     @staticmethod
-    def get_task(
-        filename, asset_dir, asset_name, replace,
-        frame_start=None, frame_end=None
+    def _import_abc_task(
+        filename, destination_path, destination_name, replace,
+        frame_start, frame_end, default_conversion
     ):
-        task = unreal.AssetImportTask()
-        options = unreal.AbcImportSettings()
-        gc_settings = unreal.AbcGeometryCacheSettings()
-        conversion_settings = unreal.AbcConversionSettings()
-        sampling_settings = unreal.AbcSamplingSettings()
+        conversion = (
+            None
+            if default_conversion
+            else {
+                "flip_u": False,
+                "flip_v": True,
+                "rotation": [0.0, 0.0, 0.0],
+                "scale": [1.0, 1.0, 1.0],
+            }
+        )
 
-        task.set_editor_property('filename', filename)
-        task.set_editor_property('destination_path', asset_dir)
-        task.set_editor_property('destination_name', asset_name)
-        task.set_editor_property('replace_existing', replace)
-        task.set_editor_property('automated', True)
-        task.set_editor_property('save', True)
-
-        options.set_editor_property(
-            'import_type', unreal.AlembicImportType.GEOMETRY_CACHE)
-
-        gc_settings.set_editor_property('flatten_tracks', False)
-
-        conversion_settings.set_editor_property('flip_u', False)
-        conversion_settings.set_editor_property('flip_v', True)
-        conversion_settings.set_editor_property(
-            'scale', unreal.Vector(x=100.0, y=100.0, z=100.0))
-        conversion_settings.set_editor_property(
-            'rotation', unreal.Vector(x=-90.0, y=0.0, z=180.0))
-
-        if frame_start is not None:
-            sampling_settings.set_editor_property('frame_start', frame_start)
-        if frame_end is not None:
-            sampling_settings.set_editor_property('frame_end', frame_end)
-
-        options.geometry_cache_settings = gc_settings
-        options.conversion_settings = conversion_settings
-        options.sampling_settings = sampling_settings
-        task.options = options
-
-        return task
-
-    def import_and_containerize(
-        self, filepath, asset_dir, asset_name, container_name,
-        frame_start, frame_end
-    ):
-        unreal.EditorAssetLibrary.make_directory(asset_dir)
-
-        task = self.get_task(
-            filepath, asset_dir, asset_name, False, frame_start, frame_end)
-
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
-
-        # Create Asset Container
-        create_container(container=container_name, path=asset_dir)
-
-    def imprint(
-        self,
-        folder_path,
-        asset_dir,
-        container_name,
-        asset_name,
-        representation,
-        frame_start,
-        frame_end,
-        product_type,
-    ):
-        data = {
-            "schema": "ayon:container-2.0",
-            "id": AYON_CONTAINER_ID,
-            "namespace": asset_dir,
-            "container_name": container_name,
-            "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": representation["id"],
-            "parent": representation["versionId"],
-            "frame_start": frame_start,
-            "frame_end": frame_end,
-            "product_type": product_type,
-            "folder_path": folder_path,
-            # TODO these should be probably removed
-            "family": product_type,
-            "asset": folder_path,
+        params = {
+            "filename": filename,
+            "destination_path": destination_path,
+            "destination_name": destination_name,
+            "replace_existing": replace,
+            "automated": True,
+            "save": True,
+            "options_properties": [
+                ["import_type", "unreal.AlembicImportType.GEOMETRY_CACHE"]
+            ],
+            "sub_options_properties": [
+                ["geometry_cache_settings", "flatten_tracks", "False"],
+                ["sampling_settings", "frame_start", str(frame_start)],
+                ["sampling_settings", "frame_end", str(frame_end)]
+            ],
+            "conversion_settings": conversion
         }
-        imprint(f"{asset_dir}/{container_name}", data)
 
-    def load(self, context, name, namespace, options):
+        send_request("import_abc_task", params=params)
+
+    def load(self, context, name=None, namespace=None, options=None):
         """Load and containerise representation into Content Browser.
 
         Args:
@@ -123,129 +68,85 @@ class PointCacheAlembicLoader(plugin.Loader):
                              This is not passed here, so namespace is set
                              by `containerise()` because only then we know
                              real path.
-            data (dict): Those would be data to be imprinted.
-
-        Returns:
-            list(str): list of container content
+            options (dict): Those would be data to be imprinted. This is not
+                            used now, data are imprinted by `containerise()`.
         """
         # Create directory for asset and Ayon container
+        root = AYON_ASSET_DIR
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
         folder_name = folder_entity["name"]
         folder_attributes = folder_entity["attrib"]
-
-        suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
-        version = context["version"]["version"]
+
+        default_conversion = options.get("default_conversion") or False
+
         # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{name}_hero"
-        else:
-            name_version = f"{name}_v{version:03d}"
-
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
-
-        container_name += suffix
-
-        frame_start = folder_attributes.get("frameStart")
-        frame_end = folder_attributes.get("frameEnd")
-
-        # If frame start and end are the same, we increase the end frame by
-        # one, otherwise Unreal will not import it
-        if frame_start == frame_end:
-            frame_end += 1
-
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = self.filepath_from_context(context)
-
-            self.import_and_containerize(
-                path, asset_dir, asset_name, container_name,
-                frame_start, frame_end)
-
-        self.imprint(
-            folder_path,
-            asset_dir,
-            container_name,
-            asset_name,
-            context["representation"],
-            frame_start,
-            frame_end,
-            context["product"]["productType"]
+        version = context["version"]["version"]
+        name_version = (
+            f"{name}_hero" if version < 0 else f"{name}_v{version:03d}"
         )
+        asset_dir, container_name = send_request(
+            "create_unique_asset_name", params={
+                "root": root,
+                "folder_name": folder_name,
+                "name": name_version})
 
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=True
-        )
+        if not send_request(
+                "does_directory_exist", params={"directory_path": asset_dir}):
+            send_request(
+                "make_directory", params={"directory_path": asset_dir})
 
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
+            frame_start = folder_attributes.get("frameStart")
+            frame_end = folder_attributes.get("frameEnd")
 
-        return asset_content
+            # If frame start and end are the same, we increase the end frame by
+            # one, otherwise Unreal will not import it
+            if frame_start == frame_end:
+                frame_end += 1
+
+            self._import_abc_task(
+                self.fname, asset_dir, asset_name, False,
+                frame_start, frame_end, default_conversion)
+
+        product_type = context["product"]["productType"]
+
+        data = {
+            "schema": "ayon:container-2.0",
+            "id": AYON_CONTAINER_ID,
+            "namespace": asset_dir,
+            "container_name": container_name,
+            "asset_name": asset_name,
+            "loader": self.__class__.__name__,
+            "representation": str(context["representation"]["id"]),
+            "parent": str(context["representation"]["versionId"]),
+            "frame_start": frame_start,
+            "frame_end": frame_end,
+            "product_type": product_type,
+            "folder_path": folder_path,
+            "default_conversion": default_conversion,
+            # TODO these should be probably removed
+            "family": product_type,
+            "asset": folder_path,
+        }
+
+        containerise(asset_dir, container_name, data)
+
+        return send_request(
+            "list_assets", params={
+                "directory_path": asset_dir,
+                "recursive": True,
+                "include_folder": True})
 
     def update(self, container, context):
-        # Create directory for folder and Ayon container
-        folder_path = context["folder"]["path"]
-        folder_name = context["folder"]["name"]
-        product_name = context["product"]["name"]
-        product_type = context["product"]["productType"]
-        version = context["version"]["version"]
         repre_entity = context["representation"]
+        filename = get_representation_path(repre_entity)
+        asset_dir = container["namespace"]
+        asset_name = container["asset_name"]
 
-        suffix = "_CON"
-        asset_name = product_name
-        if folder_name:
-            asset_name = f"{folder_name}_{product_name}"
+        default_conversion = container["default_conversion"]
 
-        # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{product_name}_hero"
-        else:
-            name_version = f"{product_name}_v{version:03d}"
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+        self._import_abc_task(
+            filename, asset_dir, asset_name, True, default_conversion)
 
-        container_name += suffix
-
-        frame_start = int(container.get("frame_start"))
-        frame_end = int(container.get("frame_end"))
-
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = get_representation_path(repre_entity)
-
-            self.import_and_containerize(
-                path, asset_dir, asset_name, container_name,
-                frame_start, frame_end)
-
-        self.imprint(
-            folder_path,
-            asset_dir,
-            container_name,
-            asset_name,
-            repre_entity,
-            frame_start,
-            frame_end,
-            product_type
-        )
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=False
-        )
-
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
-
-    def remove(self, container):
-        path = container["namespace"]
-        parent_path = os.path.dirname(path)
-
-        unreal.EditorAssetLibrary.delete_directory(path)
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            parent_path, recursive=False
-        )
-
-        if len(asset_content) == 0:
-            unreal.EditorAssetLibrary.delete_directory(parent_path)
+        super(UnrealBaseLoader, self).update(container, context)

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -1,104 +1,59 @@
 # -*- coding: utf-8 -*-
 """Load Skeletal Mesh alembics."""
-import os
 
 from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
 )
-from ayon_unreal.api import plugin
+from ayon_unreal.api.plugin import UnrealBaseLoader
 from ayon_unreal.api.pipeline import (
+    send_request,
+    containerise,
     AYON_ASSET_DIR,
-    create_container,
-    imprint,
 )
-import unreal  # noqa
 
 
-class SkeletalMeshAlembicLoader(plugin.Loader):
+class SkeletalMeshAlembicLoader(UnrealBaseLoader):
     """Load Unreal SkeletalMesh from Alembic"""
 
     product_types = {"pointcache", "skeletalMesh"}
     label = "Import Alembic Skeletal Mesh"
-    representations = {"abc"}
+    representations = ["abc"]
     icon = "cube"
     color = "orange"
 
-    root = AYON_ASSET_DIR
-
     @staticmethod
-    def get_task(filename, asset_dir, asset_name, replace, default_conversion):
-        task = unreal.AssetImportTask()
-        options = unreal.AbcImportSettings()
-        conversion_settings = unreal.AbcConversionSettings(
-            preset=unreal.AbcConversionPreset.CUSTOM,
-            flip_u=False, flip_v=False,
-            rotation=[0.0, 0.0, 0.0],
-            scale=[1.0, 1.0, 1.0])
-
-        task.set_editor_property('filename', filename)
-        task.set_editor_property('destination_path', asset_dir)
-        task.set_editor_property('destination_name', asset_name)
-        task.set_editor_property('replace_existing', replace)
-        task.set_editor_property('automated', True)
-        task.set_editor_property('save', True)
-
-        options.set_editor_property(
-            'import_type', unreal.AlembicImportType.SKELETAL)
-
-        if not default_conversion:
-            conversion_settings = unreal.AbcConversionSettings(
-                preset=unreal.AbcConversionPreset.CUSTOM,
-                flip_u=False, flip_v=False,
-                rotation=[0.0, 0.0, 0.0],
-                scale=[1.0, 1.0, 1.0])
-            options.conversion_settings = conversion_settings
-
-        task.options = options
-
-        return task
-
-    def import_and_containerize(
-        self, filepath, asset_dir, asset_name, container_name,
-        default_conversion=False
+    def _import_abc_task(
+        filename, destination_path, destination_name, replace,
+        default_conversion
     ):
-        unreal.EditorAssetLibrary.make_directory(asset_dir)
+        conversion = (
+            None
+            if default_conversion
+            else {
+                "flip_u": False,
+                "flip_v": False,
+                "rotation": [0.0, 0.0, 0.0],
+                "scale": [1.0, 1.0, 1.0],
+            }
+        )
 
-        task = self.get_task(
-            filepath, asset_dir, asset_name, False, default_conversion)
-
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
-
-        # Create Asset Container
-        create_container(container=container_name, path=asset_dir)
-
-    def imprint(
-        self,
-        folder_path,
-        asset_dir,
-        container_name,
-        asset_name,
-        representation,
-        product_type
-    ):
-        data = {
-            "schema": "ayon:container-2.0",
-            "id": AYON_CONTAINER_ID,
-            "folder_path": folder_path,
-            "namespace": asset_dir,
-            "container_name": container_name,
-            "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": representation["id"],
-            "parent": representation["versionId"],
-            "product_type": product_type,
-            # TODO these should be probably removed
-            "asset": folder_path,
-            "family": product_type,
+        params = {
+            "filename": filename,
+            "destination_path": destination_path,
+            "destination_name": destination_name,
+            "replace_existing": replace,
+            "automated": True,
+            "save": True,
+            "options_properties": [
+                ['import_type', 'unreal.AlembicImportType.SKELETAL']
+            ],
+            "conversion_settings": conversion
         }
-        imprint(f"{asset_dir}/{container_name}", data)
 
-    def load(self, context, name, namespace, options):
+        send_request("import_abc_task", params=params)
+
+    def load(self, context, name=None, namespace=None, options=None):
         """Load and containerise representation into Content Browser.
 
         Args:
@@ -114,107 +69,69 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             list(str): list of container content
         """
         # Create directory for asset and ayon container
+        root = AYON_ASSET_DIR
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
-        suffix = "_CON"
+        if options and options.get("asset_dir"):
+            root = options["asset_dir"]
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         version = context["version"]["version"]
+
         # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{name}_hero"
-        else:
-            name_version = f"{name}_v{version:03d}"
+        name_version = (
+            f"{name}_hero" if version < 0 else f"{name}_v{version:03d}"
+        )
+        asset_dir, container_name = send_request(
+            "create_unique_asset_name", params={
+                "root": root,
+                "folder_name": folder_name,
+                "name": name_version})
 
-        default_conversion = False
-        if options.get("default_conversion"):
-            default_conversion = options.get("default_conversion")
+        default_conversion = options.get("default_conversion") or False
 
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+        if not send_request(
+                "does_directory_exist", params={"directory_path": asset_dir}):
+            send_request(
+                "make_directory", params={"directory_path": asset_dir})
 
-        container_name += suffix
-
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = self.filepath_from_context(context)
-
-            self.import_and_containerize(path, asset_dir, asset_name,
-                                         container_name, default_conversion)
+            self._import_abc_task(
+                self.fname, asset_dir, asset_name, False, default_conversion)
 
         product_type = context["product"]["productType"]
-        self.imprint(
-            folder_path,
-            asset_dir,
-            container_name,
-            asset_name,
-            context["representation"],
-            product_type
-        )
 
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=True
-        )
+        data = {
+            "schema": "ayon:container-2.0",
+            "id": AYON_CONTAINER_ID,
+            "namespace": asset_dir,
+            "container_name": container_name,
+            "asset_name": asset_name,
+            "loader": self.__class__.__name__,
+            "representation": str(context["representation"]["id"]),
+            "parent": str(context["representation"]["versionId"]),
+            "default_conversion": default_conversion,
+            "product_type": product_type,
+            # TODO these should be probably removed
+            "asset": folder_path,
+            "family": product_type,
+        }
 
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
+        containerise(asset_dir, container_name, data)
 
-        return asset_content
+        return send_request(
+            "list_assets", params={
+                "directory_path": asset_dir,
+                "recursive": True,
+                "include_folder": True})
 
     def update(self, container, context):
-        folder_path = context["folder"]["path"]
-        folder_name = context["folder"]["name"]
-        product_name = context["product"]["name"]
-        product_type = context["product"]["productType"]
-        version = context["version"]["version"]
         repre_entity = context["representation"]
+        filename = get_representation_path(repre_entity)
+        asset_dir = container["namespace"]
+        asset_name = container["asset_name"]
 
-        # Create directory for folder and Ayon container
-        suffix = "_CON"
-        asset_name = product_name
-        if folder_name:
-            asset_name = f"{folder_name}_{product_name}"
-        # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{product_name}_hero"
-        else:
-            name_version = f"{product_name}_v{version:03d}"
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+        default_conversion = container["default_conversion"]
 
-        container_name += suffix
+        self._import_abc_task(
+            filename, asset_dir, asset_name, True, default_conversion)
 
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = get_representation_path(repre_entity)
-
-            self.import_and_containerize(path, asset_dir, asset_name,
-                                         container_name)
-
-        self.imprint(
-            folder_path,
-            asset_dir,
-            container_name,
-            asset_name,
-            repre_entity,
-            product_type,
-        )
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=False
-        )
-
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
-
-    def remove(self, container):
-        path = container["namespace"]
-        parent_path = os.path.dirname(path)
-
-        unreal.EditorAssetLibrary.delete_directory(path)
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            parent_path, recursive=False
-        )
-
-        if len(asset_content) == 0:
-            unreal.EditorAssetLibrary.delete_directory(parent_path)
+        super(UnrealBaseLoader, self).update(container, context)

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -1,110 +1,71 @@
 # -*- coding: utf-8 -*-
 """Load Skeletal Meshes form FBX."""
-import os
 
 from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
 )
-from ayon_unreal.api import plugin
+from ayon_unreal.api.plugin import UnrealBaseLoader
 from ayon_unreal.api.pipeline import (
+    send_request,
+    containerise,
     AYON_ASSET_DIR,
-    create_container,
-    imprint,
 )
-import unreal  # noqa
 
 
-class SkeletalMeshFBXLoader(plugin.Loader):
+class SkeletalMeshFBXLoader(UnrealBaseLoader):
     """Load Unreal SkeletalMesh from FBX."""
 
     product_types = {"rig", "skeletalMesh"}
     label = "Import FBX Skeletal Mesh"
-    representations = {"fbx"}
+    representations = ["fbx"]
     icon = "cube"
     color = "orange"
 
-    root = AYON_ASSET_DIR
-
     @staticmethod
-    def get_task(filename, asset_dir, asset_name, replace):
-        task = unreal.AssetImportTask()
-        options = unreal.FbxImportUI()
-
-        task.set_editor_property('filename', filename)
-        task.set_editor_property('destination_path', asset_dir)
-        task.set_editor_property('destination_name', asset_name)
-        task.set_editor_property('replace_existing', replace)
-        task.set_editor_property('automated', True)
-        task.set_editor_property('save', True)
-
-        options.set_editor_property(
-            'automated_import_should_detect_type', False)
-        options.set_editor_property('import_as_skeletal', True)
-        options.set_editor_property('import_animations', False)
-        options.set_editor_property('import_mesh', True)
-        options.set_editor_property('import_materials', False)
-        options.set_editor_property('import_textures', False)
-        options.set_editor_property('skeleton', None)
-        options.set_editor_property('create_physics_asset', False)
-
-        options.set_editor_property(
-            'mesh_type_to_import',
-            unreal.FBXImportType.FBXIT_SKELETAL_MESH)
-
-        options.skeletal_mesh_import_data.set_editor_property(
-            'import_content_type',
-            unreal.FBXImportContentType.FBXICT_ALL)
-
-        options.skeletal_mesh_import_data.set_editor_property(
-            'normal_import_method',
-            unreal.FBXNormalImportMethod.FBXNIM_IMPORT_NORMALS)
-
-        task.options = options
-
-        return task
-
-    def import_and_containerize(
-        self, filepath, asset_dir, asset_name, container_name
+    def _import_fbx_task(
+        filename, destination_path, destination_name, replace
     ):
-        unreal.EditorAssetLibrary.make_directory(asset_dir)
-
-        task = self.get_task(
-            filepath, asset_dir, asset_name, False)
-
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
-
-        # Create Asset Container
-        create_container(container=container_name, path=asset_dir)
-
-    def imprint(
-        self,
-        folder_path,
-        asset_dir,
-        container_name,
-        asset_name,
-        representation,
-        product_type
-    ):
-        data = {
-            "schema": "ayon:container-2.0",
-            "id": AYON_CONTAINER_ID,
-            "folder_path": folder_path,
-            "namespace": asset_dir,
-            "container_name": container_name,
-            "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": representation["id"],
-            "parent": representation["versionId"],
-            "product_type": product_type,
-            # TODO these should be probably removed
-            "asset": folder_path,
-            "family": product_type,
+        params = {
+            "filename": filename,
+            "destination_path": destination_path,
+            "destination_name": destination_name,
+            "replace_existing": replace,
+            "automated": True,
+            "save": True,
+            "options_properties": [
+                ["import_animations", "False"],
+                ["import_mesh", "True"],
+                ["import_materials", "False"],
+                ["import_textures", "False"],
+                ["skeleton", "None"],
+                ["create_physics_asset", "False"],
+                ["mesh_type_to_import",
+                 "unreal.FBXImportType.FBXIT_SKELETAL_MESH"]
+            ],
+            "sub_options_properties": [
+                [
+                    "skeletal_mesh_import_data",
+                    "import_content_type",
+                    "unreal.FBXImportContentType.FBXICT_ALL"
+                ],
+                [
+                    "skeletal_mesh_import_data",
+                    "normal_import_method",
+                    "unreal.FBXNormalImportMethod.FBXNIM_IMPORT_NORMALS"
+                ]
+            ]
         }
-        imprint(f"{asset_dir}/{container_name}", data)
 
-    def load(self, context, name, namespace, options):
+        send_request("import_fbx_task", params=params)
+
+    def load(self, context, name=None, namespace=None, options=None):
         """Load and containerise representation into Content Browser.
+
+        This is a two step process. First, import FBX to temporary path and
+        then call `containerise()` on it - this moves all content to new
+        directory and then it will create AssetContainer there and imprint it
+        with metadata. This will mark this path as container.
 
         Args:
             context (dict): application context
@@ -113,110 +74,66 @@ class SkeletalMeshFBXLoader(plugin.Loader):
                              This is not passed here, so namespace is set
                              by `containerise()` because only then we know
                              real path.
-            data (dict): Those would be data to be imprinted.
-
-        Returns:
-            list(str): list of container content
+            options (dict): Those would be data to be imprinted. This is not
+                            used now, data are imprinted by `containerise()`.
         """
-        # Create directory for asset and Ayon container
-        folder_name = context["folder"]["name"]
-        product_type = context["product"]["productType"]
-        suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
-        version_entity = context["version"]
-        # Check if version is hero version and use different name
-        version = version_entity["version"]
-        if version < 0:
-            name_version = f"{name}_hero"
-        else:
-            name_version = f"{name}_v{version:03d}"
-
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix=""
-        )
-
-        container_name += suffix
-
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = self.filepath_from_context(context)
-
-            self.import_and_containerize(
-                path, asset_dir, asset_name, container_name)
-
-        self.imprint(
-            folder_name,
-            asset_dir,
-            container_name,
-            asset_name,
-            context["representation"],
-            product_type
-        )
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=True
-        )
-
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
-
-        return asset_content
-
-    def update(self, container, context):
+        # Create directory for asset and OpenPype container
+        root = AYON_ASSET_DIR
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
-        product_name = context["product"]["name"]
-        product_type = context["product"]["productType"]
+        if options and options.get("asset_dir"):
+            root = options["asset_dir"]
+        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         version = context["version"]["version"]
-        repre_entity = context["representation"]
 
-        # Create directory for asset and Ayon container
-        suffix = "_CON"
-        asset_name = product_name
-        if folder_name:
-            asset_name = f"{folder_name}_{product_name}"
         # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{product_name}_hero"
-        else:
-            name_version = f"{product_name}_v{version:03d}"
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
-
-        container_name += suffix
-
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = get_representation_path(repre_entity)
-
-            self.import_and_containerize(
-                path, asset_dir, asset_name, container_name)
-
-        self.imprint(
-            folder_path, 
-            asset_dir,
-            container_name,
-            asset_name,
-            repre_entity,
-            product_type
+        name_version = (
+            f"{name}_hero" if version < 0 else f"{name}_v{version:03d}"
         )
+        asset_dir, container_name = send_request(
+            "create_unique_asset_name", params={
+                "root": root,
+                "folder_name": folder_name,
+                "name": name_version})
 
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=False
-        )
+        if not send_request(
+                "does_directory_exist", params={"directory_path": asset_dir}):
+            send_request(
+                "make_directory", params={"directory_path": asset_dir})
 
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
+            self._import_fbx_task(self.fname, asset_dir, asset_name, False)
 
-    def remove(self, container):
-        path = container["namespace"]
-        parent_path = os.path.dirname(path)
+        product_type = context["product"]["productType"]
 
-        unreal.EditorAssetLibrary.delete_directory(path)
+        data = {
+            "schema": "ayon:container-2.0",
+            "id": AYON_CONTAINER_ID,
+            "namespace": asset_dir,
+            "container_name": container_name,
+            "asset_name": asset_name,
+            "loader": self.__class__.__name__,
+            "representation": str(context["representation"]["id"]),
+            "parent": str(context["representation"]["versionId"]),
+            "product_type": product_type,
+            # TODO these should be probably removed
+            "asset": folder_path,
+            "family": product_type,
+        }
 
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            parent_path, recursive=False
-        )
+        containerise(asset_dir, container_name, data)
 
-        if len(asset_content) == 0:
-            unreal.EditorAssetLibrary.delete_directory(parent_path)
+        return send_request(
+            "list_assets", params={
+                "directory_path": asset_dir,
+                "recursive": True,
+                "include_folder": True})
+
+    def update(self, container, context):
+        repre_entity = context["representation"]
+        filename = get_representation_path(repre_entity)
+        asset_dir = container["namespace"]
+        asset_name = container["asset_name"]
+
+        self._import_fbx_task(filename, asset_dir, asset_name, True)
+
+        super(UnrealBaseLoader, self).update(container, context)

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -1,105 +1,64 @@
 # -*- coding: utf-8 -*-
 """Loader for Static Mesh alembics."""
-import os
 
 from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
 )
-from ayon_unreal.api import plugin
+from ayon_unreal.api.plugin import UnrealBaseLoader
 from ayon_unreal.api.pipeline import (
+    send_request,
+    containerise,
     AYON_ASSET_DIR,
-    create_container,
-    imprint,
 )
-import unreal  # noqa
 
 
-class StaticMeshAlembicLoader(plugin.Loader):
+class StaticMeshAlembicLoader(UnrealBaseLoader):
     """Load Unreal StaticMesh from Alembic"""
 
     product_types = {"model", "staticMesh"}
     label = "Import Alembic Static Mesh"
-    representations = {"abc"}
+    representations = ["abc"]
     icon = "cube"
     color = "orange"
 
     root = AYON_ASSET_DIR
 
     @staticmethod
-    def get_task(filename, asset_dir, asset_name, replace, default_conversion):
-        task = unreal.AssetImportTask()
-        options = unreal.AbcImportSettings()
-        sm_settings = unreal.AbcStaticMeshSettings()
-
-        task.set_editor_property('filename', filename)
-        task.set_editor_property('destination_path', asset_dir)
-        task.set_editor_property('destination_name', asset_name)
-        task.set_editor_property('replace_existing', replace)
-        task.set_editor_property('automated', True)
-        task.set_editor_property('save', True)
-
-        # set import options here
-        # Unreal 4.24 ignores the settings. It works with Unreal 4.26
-        options.set_editor_property(
-            'import_type', unreal.AlembicImportType.STATIC_MESH)
-
-        sm_settings.set_editor_property('merge_meshes', True)
-
-        if not default_conversion:
-            conversion_settings = unreal.AbcConversionSettings(
-                preset=unreal.AbcConversionPreset.CUSTOM,
-                flip_u=False, flip_v=False,
-                rotation=[0.0, 0.0, 0.0],
-                scale=[1.0, 1.0, 1.0])
-            options.conversion_settings = conversion_settings
-
-        options.static_mesh_settings = sm_settings
-        task.options = options
-
-        return task
-
-    def import_and_containerize(
-        self, filepath, asset_dir, asset_name, container_name,
-        default_conversion=False
+    def _import_abc_task(
+        filename, destination_path, destination_name, replace,
+        default_conversion
     ):
-        unreal.EditorAssetLibrary.make_directory(asset_dir)
+        conversion = (
+            None
+            if default_conversion
+            else {
+                "flip_u": False,
+                "flip_v": False,
+                "rotation": [0.0, 0.0, 0.0],
+                "scale": [1.0, 1.0, 1.0],
+            }
+        )
 
-        task = self.get_task(
-            filepath, asset_dir, asset_name, False, default_conversion)
-
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
-
-        # Create Asset Container
-        create_container(container=container_name, path=asset_dir)
-
-    def imprint(
-        self,
-        folder_path,
-        asset_dir,
-        container_name,
-        asset_name,
-        representation,
-        product_type,
-    ):
-        data = {
-            "schema": "ayon:container-2.0",
-            "id": AYON_CONTAINER_ID,
-            "folder_path": folder_path,
-            "namespace": asset_dir,
-            "container_name": container_name,
-            "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": representation["id"],
-            "parent": representation["versionId"],
-            "product_type": product_type,
-            # TODO these should be probably removed
-            "asset": folder_path,
-            "family": product_type
+        params = {
+            "filename": filename,
+            "destination_path": destination_path,
+            "destination_name": destination_name,
+            "replace_existing": replace,
+            "automated": True,
+            "save": True,
+            "options_properties": [
+                ['import_type', 'unreal.AlembicImportType.STATIC_MESH']
+            ],
+            "sub_options_properties": [
+                ["static_mesh_settings", "merge_meshes", "True"]
+            ],
+            "conversion_settings": conversion
         }
-        imprint(f"{asset_dir}/{container_name}", data)
 
-    def load(self, context, name, namespace, options):
+        send_request("import_abc_task", params=params)
+
+    def load(self, context, name=None, namespace=None, options=None):
         """Load and containerise representation into Content Browser.
 
         Args:
@@ -113,111 +72,72 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         Returns:
             list(str): list of container content
+
         """
         # Create directory for asset and Ayon container
-        folder_path = context["folder"]["path"]
-        folder_name = context["folder"]["path"]
-
-        suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
-        version = context["version"]["version"]
-        # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{name}_hero"
-        else:
-            name_version = f"{name}_v{version:03d}"
-
-        default_conversion = False
-        if options.get("default_conversion"):
-            default_conversion = options.get("default_conversion")
-
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
-
-        container_name += suffix
-
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = self.filepath_from_context(context)
-
-            self.import_and_containerize(path, asset_dir, asset_name,
-                                         container_name, default_conversion)
-
-        product_type = context["product"]["productType"]
-        self.imprint(
-            folder_path,
-            asset_dir,
-            container_name,
-            asset_name,
-            context["representation"],
-            product_type
-        )
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=False
-        )
-
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
-
-        return asset_content
-
-    def update(self, container, context):
+        root = AYON_ASSET_DIR
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
-        product_name = context["product"]["name"]
-        product_type = context["product"]["productType"]
-        repre_entity = context["representation"]
-
-        # Create directory for asset and Ayon container
-        suffix = "_CON"
-        asset_name = product_name
-        if folder_name:
-            asset_name = f"{folder_name}_{product_name}"
+        if options and options.get("asset_dir"):
+            root = options["asset_dir"]
+        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         version = context["version"]["version"]
+
         # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{product_name}_hero"
-        else:
-            name_version = f"{product_name}_v{version:03d}"
-
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
-
-        container_name += suffix
-
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = get_representation_path(repre_entity)
-
-            self.import_and_containerize(path, asset_dir, asset_name,
-                                         container_name)
-
-        self.imprint(
-            folder_path,
-            asset_dir,
-            container_name,
-            asset_name,
-            repre_entity,
-            product_type
+        name_version = (
+            f"{name}_hero" if version < 0 else f"{name}_v{version:03d}"
         )
+        asset_dir, container_name = send_request(
+            "create_unique_asset_name", params={
+                "root": root,
+                "folder_name": folder_name,
+                "name": name_version})
 
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=False
-        )
+        default_conversion = options.get("default_conversion") or False
 
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
+        if not send_request(
+                "does_directory_exist", params={"directory_path": asset_dir}):
+            send_request(
+                "make_directory", params={"directory_path": asset_dir})
 
-    def remove(self, container):
-        path = container["namespace"]
-        parent_path = os.path.dirname(path)
+            self._import_abc_task(
+                self.fname, asset_dir, asset_name, False, default_conversion)
 
-        unreal.EditorAssetLibrary.delete_directory(path)
+        product_type = context["product"]["productType"]
 
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            parent_path, recursive=False
-        )
+        data = {
+            "schema": "ayon:container-2.0",
+            "id": AYON_CONTAINER_ID,
+            "namespace": asset_dir,
+            "container_name": container_name,
+            "asset_name": asset_name,
+            "loader": self.__class__.__name__,
+            "representation": str(context["representation"]["id"]),
+            "parent": str(context["representation"]["versionId"]),
+            "default_conversion": default_conversion,
+            "product_type": product_type,
+            # TODO these should be probably removed
+            "asset": folder_path,
+            "family": product_type,
+        }
 
-        if len(asset_content) == 0:
-            unreal.EditorAssetLibrary.delete_directory(parent_path)
+        containerise(asset_dir, container_name, data)
+
+        return send_request(
+            "list_assets", params={
+                "directory_path": asset_dir,
+                "recursive": True,
+                "include_folder": True})
+
+    def update(self, container, context):
+        repre_entity = context["representation"]
+        filename = get_representation_path(repre_entity)
+        asset_dir = container["namespace"]
+        asset_name = container["asset_name"]
+
+        default_conversion = container["default_conversion"]
+
+        self._import_abc_task(
+            filename, asset_dir, asset_name, True, default_conversion)
+
+        super(UnrealBaseLoader, self).update(container, context)

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -1,97 +1,53 @@
 # -*- coding: utf-8 -*-
 """Load Static meshes form FBX."""
-import os
 
 from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
 )
-from ayon_unreal.api import plugin
+from ayon_unreal.api.plugin import UnrealBaseLoader
 from ayon_unreal.api.pipeline import (
-    AYON_ASSET_DIR,
-    create_container,
-    imprint,
+    send_request,
+    containerise,
+    AYON_ASSET_DIR
 )
-import unreal  # noqa
 
 
-class StaticMeshFBXLoader(plugin.Loader):
+class StaticMeshFBXLoader(UnrealBaseLoader):
     """Load Unreal StaticMesh from FBX."""
 
     product_types = {"model", "staticMesh"}
     label = "Import FBX Static Mesh"
-    representations = {"fbx"}
+    representations = ["fbx"]
     icon = "cube"
     color = "orange"
 
     root = AYON_ASSET_DIR
 
     @staticmethod
-    def get_task(filename, asset_dir, asset_name, replace):
-        task = unreal.AssetImportTask()
-        options = unreal.FbxImportUI()
-        import_data = unreal.FbxStaticMeshImportData()
-
-        task.set_editor_property('filename', filename)
-        task.set_editor_property('destination_path', asset_dir)
-        task.set_editor_property('destination_name', asset_name)
-        task.set_editor_property('replace_existing', replace)
-        task.set_editor_property('automated', True)
-        task.set_editor_property('save', True)
-
-        # set import options here
-        options.set_editor_property(
-            'automated_import_should_detect_type', False)
-        options.set_editor_property('import_animations', False)
-
-        import_data.set_editor_property('combine_meshes', True)
-        import_data.set_editor_property('remove_degenerates', False)
-
-        options.static_mesh_import_data = import_data
-        task.options = options
-
-        return task
-
-    def import_and_containerize(
-        self, filepath, asset_dir, asset_name, container_name
+    def _import_fbx_task(
+        filename, destination_path, destination_name, replace
     ):
-        unreal.EditorAssetLibrary.make_directory(asset_dir)
-
-        task = self.get_task(
-            filepath, asset_dir, asset_name, False)
-
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
-
-        # Create Asset Container
-        create_container(container=container_name, path=asset_dir)
-
-    def imprint(
-        self,
-        folder_path,
-        asset_dir,
-        container_name,
-        asset_name,
-        repre_entity,
-        product_type
-    ):
-        data = {
-            "schema": "ayon:container-2.0",
-            "id": AYON_CONTAINER_ID,
-            "namespace": asset_dir,
-            "folder_path": folder_path,
-            "container_name": container_name,
-            "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": repre_entity["id"],
-            "parent": repre_entity["versionId"],
-            "product_type": product_type,
-            # TODO these shold be probably removed
-            "asset": folder_path,
-            "family": product_type,
+        params = {
+            "filename": filename,
+            "destination_path": destination_path,
+            "destination_name": destination_name,
+            "replace_existing": replace,
+            "automated": True,
+            "save": True,
+            "options_properties": [
+                ["automated_import_should_detect_type", "False"],
+                ["import_animations", "False"]
+            ],
+            "sub_options_properties": [
+                ["static_mesh_import_data", "combine_meshes", "True"],
+                ["static_mesh_import_data", "remove_degenerates", "False"]
+            ]
         }
-        imprint(f"{asset_dir}/{container_name}", data)
 
-    def load(self, context, name, namespace, options):
+        send_request("import_fbx_task", params=params)
+
+    def load(self, context, name=None, namespace=None, options=None):
         """Load and containerise representation into Content Browser.
 
         Args:
@@ -106,104 +62,64 @@ class StaticMeshFBXLoader(plugin.Loader):
         Returns:
             list(str): list of container content
         """
+
         # Create directory for asset and Ayon container
+        root = AYON_ASSET_DIR
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
-        suffix = "_CON"
+        if options and options.get("asset_dir"):
+            root = options["asset_dir"]
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         version = context["version"]["version"]
+
         # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{name}_hero"
-        else:
-            name_version = f"{name}_v{version:03d}"
-
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix=""
+        name_version = (
+            f"{name}_hero" if version < 0 else f"{name}_v{version:03d}"
         )
+        asset_dir, container_name = send_request(
+            "create_unique_asset_name", params={
+                "root": root,
+                "folder_name": folder_name,
+                "name": name_version})
 
-        container_name += suffix
+        if not send_request(
+                "does_directory_exist", params={"directory_path": asset_dir}):
+            send_request(
+                "make_directory", params={"directory_path": asset_dir})
 
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = self.filepath_from_context(context)
+            self._import_fbx_task(self.fname, asset_dir, asset_name, False)
 
-            self.import_and_containerize(
-                path, asset_dir, asset_name, container_name)
+        product_type = context["product"]["productType"]
 
-        self.imprint(
-            folder_path,
-            asset_dir,
-            container_name,
-            asset_name,
-            context["representation"],
-            context["product"]["productType"]
-        )
+        data = {
+            "schema": "ayon:container-2.0",
+            "id": AYON_CONTAINER_ID,
+            "namespace": asset_dir,
+            "container_name": container_name,
+            "asset_name": asset_name,
+            "loader": self.__class__.__name__,
+            "representation": str(context["representation"]["id"]),
+            "parent": str(context["representation"]["versionId"]),
+            "product_type": product_type,
+            # TODO these should be probably removed
+            "asset": folder_path,
+            "family": product_type,
+        }
 
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=True
-        )
+        containerise(asset_dir, container_name, data)
 
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
-
-        return asset_content
+        return send_request(
+            "list_assets", params={
+                "directory_path": asset_dir,
+                "recursive": True,
+                "include_folder": True})
 
     def update(self, container, context):
-        folder_path = context["folder"]["path"]
-        folder_name = context["folder"]["name"]
-        product_name = context["product"]["name"]
-        product_type = context["product"]["productType"]
-        version = context["version"]["version"]
         repre_entity = context["representation"]
+        filename = get_representation_path(repre_entity)
+        asset_dir = container["namespace"]
+        asset_name = container["asset_name"]
 
-        # Create directory for asset and Ayon container
-        suffix = "_CON"
-        asset_name = product_name
-        if folder_name:
-            asset_name = f"{folder_name}_{product_name}"
-        # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{product_name}_hero"
-        else:
-            name_version = f"{product_name}_v{version:03d}"
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+        self._import_fbx_task(filename, asset_dir, asset_name, True)
 
-        container_name += suffix
-
-        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = get_representation_path(repre_entity)
-
-            self.import_and_containerize(
-                path, asset_dir, asset_name, container_name)
-
-        self.imprint(
-            folder_path,
-            asset_dir,
-            container_name,
-            asset_name,
-            repre_entity,
-            product_type,
-        )
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=False
-        )
-
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
-
-    def remove(self, container):
-        path = container["namespace"]
-        parent_path = os.path.dirname(path)
-
-        unreal.EditorAssetLibrary.delete_directory(path)
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            parent_path, recursive=False
-        )
-
-        if len(asset_content) == 0:
-            unreal.EditorAssetLibrary.delete_directory(parent_path)
+        super(UnrealBaseLoader, self).update(container, context)

--- a/client/ayon_unreal/plugins/load/load_uasset.py
+++ b/client/ayon_unreal/plugins/load/load_uasset.py
@@ -7,23 +7,26 @@ from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
 )
-from ayon_unreal.api import plugin
-from ayon_unreal.api import pipeline as unreal_pipeline
-import unreal  # noqa
+from ayon_unreal.api.plugin import UnrealBaseLoader
+from ayon_unreal.api.pipeline import (
+    send_request,
+    containerise,
+    AYON_ASSET_DIR,
+)
 
 
-class UAssetLoader(plugin.Loader):
+class UAssetLoader(UnrealBaseLoader):
     """Load UAsset."""
 
     product_types = {"uasset"}
     label = "Load UAsset"
-    representations = {"uasset"}
+    representations = ["uasset"]
     icon = "cube"
     color = "orange"
 
     extension = "uasset"
 
-    def load(self, context, name, namespace, options):
+    def load(self, context, name=None, namespace=None, options=None):
         """Load and containerise representation into Content Browser.
 
         Args:
@@ -34,45 +37,42 @@ class UAssetLoader(plugin.Loader):
                              by `containerise()` because only then we know
                              real path.
             options (dict): Those would be data to be imprinted. This is not
-                used now, data are imprinted by `containerise()`.
-
-        Returns:
-            list(str): list of container content
+                            used now, data are imprinted by `containerise()`.
         """
 
         # Create directory for asset and Ayon container
-        root = unreal_pipeline.AYON_ASSET_DIR
+        root = AYON_ASSET_DIR
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/{folder_name}/{name}", suffix=""
-        )
+
+        asset_dir, container_name = send_request(
+            "create_unique_asset_name", params={
+                "root": root,
+                "folder_name": folder_name,
+                "name": name})
 
         unique_number = 1
-        while unreal.EditorAssetLibrary.does_directory_exist(
-            f"{asset_dir}_{unique_number:02}"
-        ):
+        while send_request(
+                "does_directory_exist",
+                params={"directory_path": f"{asset_dir}_{unique_number:02}"}):
             unique_number += 1
 
         asset_dir = f"{asset_dir}_{unique_number:02}"
         container_name = f"{container_name}_{unique_number:02}{suffix}"
 
-        unreal.EditorAssetLibrary.make_directory(asset_dir)
+        send_request(
+            "make_directory", params={"directory_path": asset_dir})
 
+        project_content_dir = send_request("project_content_dir")
         destination_path = asset_dir.replace(
-            "/Game", Path(unreal.Paths.project_content_dir()).as_posix(), 1)
+            "/Game", Path(project_content_dir).as_posix(), 1)
 
         path = self.filepath_from_context(context)
         shutil.copy(
             path,
             f"{destination_path}/{name}_{unique_number:02}.{self.extension}")
-
-        # Create Asset Container
-        unreal_pipeline.create_container(
-            container=container_name, path=asset_dir)
 
         product_type = context["product"]["productType"]
         data = {
@@ -82,28 +82,24 @@ class UAssetLoader(plugin.Loader):
             "folder_path": folder_path,
             "container_name": container_name,
             "asset_name": asset_name,
-            "loader": str(self.__class__.__name__),
-            "representation": context["representation"]["id"],
-            "parent": context["representation"]["versionId"],
+            "loader": self.__class__.__name__,
+            "representation": str(context["representation"]["id"]),
+            "parent": str(context["representation"]["versionId"]),
             "product_type": product_type,
             # TODO these should be probably removed
             "asset": folder_path,
-            "family": product_type,
+            "family": product_type
         }
-        unreal_pipeline.imprint(f"{asset_dir}/{container_name}", data)
 
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=True
-        )
+        containerise(asset_dir, container_name, data)
 
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
-
-        return asset_content
+        return send_request(
+            "list_assets", params={
+                "directory_path": asset_dir,
+                "recursive": True,
+                "include_folder": True})
 
     def update(self, container, context):
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
-
         asset_dir = container["namespace"]
 
         product_name = context["product"]["name"]
@@ -111,17 +107,13 @@ class UAssetLoader(plugin.Loader):
 
         unique_number = container["container_name"].split("_")[-2]
 
+        project_content_dir = send_request("project_content_dir")
         destination_path = asset_dir.replace(
-            "/Game", Path(unreal.Paths.project_content_dir()).as_posix(), 1)
+            "/Game", Path(project_content_dir).as_posix(), 1)
 
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=False, include_folder=True
-        )
-
-        for asset in asset_content:
-            obj = ar.get_asset_by_object_path(asset).get_asset()
-            if obj.get_class().get_name() != "AyonAssetContainer":
-                unreal.EditorAssetLibrary.delete_asset(asset)
+        send_request(
+            "delete_assets_in_dir_but_container",
+            params={"asset_dir": asset_dir})
 
         update_filepath = get_representation_path(repre_entity)
 
@@ -130,35 +122,7 @@ class UAssetLoader(plugin.Loader):
             f"{destination_path}/{product_name}_{unique_number}.{self.extension}"
         )
 
-        container_path = f'{container["namespace"]}/{container["objectName"]}'
-        # update metadata
-        unreal_pipeline.imprint(
-            container_path,
-            {
-                "representation": repre_entity["id"],
-                "parent": repre_entity["versionId"],
-            }
-        )
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            asset_dir, recursive=True, include_folder=True
-        )
-
-        for a in asset_content:
-            unreal.EditorAssetLibrary.save_asset(a)
-
-    def remove(self, container):
-        path = container["namespace"]
-        parent_path = Path(path).parent.as_posix()
-
-        unreal.EditorAssetLibrary.delete_directory(path)
-
-        asset_content = unreal.EditorAssetLibrary.list_assets(
-            parent_path, recursive=False
-        )
-
-        if len(asset_content) == 0:
-            unreal.EditorAssetLibrary.delete_directory(parent_path)
+        super(UAssetLoader, self).update(container, context)
 
 
 class UMapLoader(UAssetLoader):
@@ -166,6 +130,6 @@ class UMapLoader(UAssetLoader):
 
     product_types = {"uasset"}
     label = "Load Level"
-    representations = {"umap"}
+    representations = ["umap"]
 
     extension = "umap"

--- a/client/ayon_unreal/plugins/publish/collect_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/collect_render_instances.py
@@ -71,7 +71,7 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
                     new_data["productType"] = product_type
                     new_data["family"] = product_type
                     new_data["families"] = [product_type, "review"]
-                    new_data["parent"] = data.get("parent")
+                    new_data["version_id"] = data.get("version_id")
                     new_data["level"] = data.get("level")
                     new_data["output"] = s.get('output')
                     new_data["fps"] = seq.get_display_rate().numerator

--- a/client/ayon_unreal/plugins/publish/extract_layout.py
+++ b/client/ayon_unreal/plugins/publish/extract_layout.py
@@ -53,10 +53,10 @@ class ExtractLayout(publish.Extractor):
                 try:
                     asset_container = ar.get_assets(filter)[0].get_asset()
                 except IndexError:
-                    self.log.error("AssetContainer not found.")
+                    self.log.error("AyonAssetContainer not found.")
                     return
 
-                parent_id = eal.get_metadata_tag(asset_container, "parent")
+                parent_id = eal.get_metadata_tag(asset_container, "version_id")
                 family = eal.get_metadata_tag(asset_container, "family")
 
                 self.log.info("Parent: {}".format(parent_id))


### PR DESCRIPTION
> [!NOTE]
> This is port of https://github.com/ynput/ayon-core/pull/111 from ayon-core to the new repo.

## Brief description
Run unreal commands from OP through websocket communication.

## Description
UE has the ability to have its python to be called remotely. This PR allow us to run all UIs as separete processes that are comunicating with UE. We'll no longer need to install PySide2 to Unreal.

PR linked to https://github.com/ynput/OpenPype/pull/4075

## Tested workflows

### Publishing

- [ ] Camera
- [ ] Layout
- ⛔ Level (see https://github.com/ynput/ayon-core/pull/111#issuecomment-2152273399)
- [ ] Look
- [ ] Render
	- [ ] Local
	- [ ] Farm
- [ ] Static Mesh FBX
- [ ] UAsset

### Loading

- ⛔ Animation (alembic)
- [ ] Animation (FBX)
- ⛔ Camera (FBX)
- ⛔ Pointcache (alembic)
- ⛔ Layout (json)
- [ ] Layout from existing
- [ ] Skeletal Mesh (alembic)
- [ ] Skeletal Mesh (FBX)
- ⛔ Static Mesh (alembic)
- [ ] Static Mesh (FBX)
- [ ] Load UAsset
- ⛔ Load Yeti Cache