### PR TITLE
Unreal: Standalone loader for animation

### DIFF
--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -25,7 +25,7 @@ class AnimationFBXLoader(plugin.Loader):
     color = "orange"
 
     def _import_animation(
-        self, path, asset_dir, asset_name, skeleton, automated
+        self, path, asset_dir, asset_name, skeleton, automated, replace=False
     ):
         task = unreal.AssetImportTask()
         task.options = unreal.FbxImportUI()
@@ -35,7 +35,7 @@ class AnimationFBXLoader(plugin.Loader):
         task.set_editor_property('filename', path)
         task.set_editor_property('destination_path', asset_dir)
         task.set_editor_property('destination_name', asset_name)
-        task.set_editor_property('replace_existing', False)
+        task.set_editor_property('replace_existing', replace)
         task.set_editor_property('automated', automated)
         task.set_editor_property('save', False)
 
@@ -352,7 +352,7 @@ class AnimationFBXLoader(plugin.Loader):
         skeleton = skeletal_mesh.get_editor_property('skeleton')
 
         self._import_animation(
-            source_path, destination_path, folder_name, skeleton, True)
+            source_path, destination_path, folder_name, skeleton, True, True)
 
         container_path = f'{container["namespace"]}/{container["objectName"]}'
         # update metadata

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -8,9 +8,11 @@ from unreal import EditorAssetLibrary
 from unreal import MovieSceneSkeletalAnimationTrack
 from unreal import MovieSceneSkeletalAnimationSection
 
+import ayon_api
 from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.pipeline import (
     get_representation_path,
+    get_current_project_name,
     AYON_CONTAINER_ID
 )
 from ayon_unreal.api import plugin
@@ -26,32 +28,11 @@ class AnimationFBXLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    def _process(self, path, asset_dir, asset_name, instance_name):
-        automated = False
-        actor = None
-
+    def _import_animation(
+        self, path, asset_dir, asset_name, skeleton, automated
+    ):
         task = unreal.AssetImportTask()
         task.options = unreal.FbxImportUI()
-
-        if instance_name:
-            automated = True
-            # Old method to get the actor
-            # actor_name = 'PersistentLevel.' + instance_name
-            # actor = unreal.EditorLevelLibrary.get_actor_reference(actor_name)
-            actors = unreal.EditorLevelLibrary.get_all_level_actors()
-            for a in actors:
-                if a.get_class().get_name() != "SkeletalMeshActor":
-                    continue
-                if a.get_actor_label() == instance_name:
-                    actor = a
-                    break
-            if not actor:
-                raise Exception(f"Could not find actor {instance_name}")
-            skeleton = actor.skeletal_mesh_component.skeletal_mesh.skeleton
-            task.options.set_editor_property('skeleton', skeleton)
-
-        if not actor:
-            return None
 
         folder_entity = get_current_folder_entity(fields=["attrib.fps"])
 
@@ -72,6 +53,7 @@ class AnimationFBXLoader(plugin.Loader):
         task.options.set_editor_property('import_mesh', False)
         task.options.set_editor_property('import_animations', True)
         task.options.set_editor_property('override_full_name', True)
+        task.options.set_editor_property('skeleton', skeleton)
 
         task.options.anim_sequence_import_data.set_editor_property(
             'animation_length',
@@ -93,6 +75,32 @@ class AnimationFBXLoader(plugin.Loader):
             'convert_scene', True)
 
         unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+
+    def _process(self, path, asset_dir, asset_name, instance_name):
+        automated = False
+        actor = None
+
+        if instance_name:
+            automated = True
+            # Old method to get the actor
+            # actor_name = 'PersistentLevel.' + instance_name
+            # actor = unreal.EditorLevelLibrary.get_actor_reference(actor_name)
+            actors = unreal.EditorLevelLibrary.get_all_level_actors()
+            for a in actors:
+                if a.get_class().get_name() != "SkeletalMeshActor":
+                    continue
+                if a.get_actor_label() == instance_name:
+                    actor = a
+                    break
+            if not actor:
+                raise Exception(f"Could not find actor {instance_name}")
+            skeleton = actor.skeletal_mesh_component.skeletal_mesh.skeleton
+
+        if not actor:
+            return None
+
+        self._import_animation(
+            path, asset_dir, asset_name, skeleton, automated)
 
         asset_content = EditorAssetLibrary.list_assets(
             asset_dir, recursive=True, include_folder=True
@@ -117,72 +125,9 @@ class AnimationFBXLoader(plugin.Loader):
 
         return animation
 
-    def load(self, context, name, namespace, options=None):
-        """
-        Load and containerise representation into Content Browser.
-
-        This is two step process. First, import FBX to temporary path and
-        then call `containerise()` on it - this moves all content to new
-        directory and then it will create AssetContainer there and imprint it
-        with metadata. This will mark this path as container.
-
-        Args:
-            context (dict): application context
-            name (str): Product name
-            namespace (str): in Unreal this is basically path to container.
-                             This is not passed here, so namespace is set
-                             by `containerise()` because only then we know
-                             real path.
-            data (dict): Those would be data to be imprinted. This is not used
-                         now, data are imprinted by `containerise()`.
-
-        Returns:
-            list(str): list of container content
-        """
-        # Create directory for asset and Ayon container
-        root = "/Game/Ayon"
-        folder_path = context["folder"]["path"]
-        hierarchy = folder_path.lstrip("/").split("/")
-        folder_name = hierarchy.pop(-1)
-        product_type = context["product"]["productType"]
-
-        suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
-        tools = unreal.AssetToolsHelpers().get_asset_tools()
-        asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/Animations/{folder_name}/{name}", suffix="")
-
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
-
-        _filter = unreal.ARFilter(
-            class_names=["World"],
-            package_paths=[f"{root}/{hierarchy[0]}"],
-            recursive_paths=False)
-        levels = ar.get_assets(_filter)
-        master_level = levels[0].get_asset().get_path_name()
-
-        hierarchy_dir = root
-        for h in hierarchy:
-            hierarchy_dir = f"{hierarchy_dir}/{h}"
-        hierarchy_dir = f"{hierarchy_dir}/{folder_name}"
-
-        _filter = unreal.ARFilter(
-            class_names=["World"],
-            package_paths=[f"{hierarchy_dir}/"],
-            recursive_paths=True)
-        levels = ar.get_assets(_filter)
-        level = levels[0].get_asset().get_path_name()
-
-        unreal.EditorLevelLibrary.save_all_dirty_levels()
-        unreal.EditorLevelLibrary.load_level(level)
-
-        container_name += suffix
-
-        EditorAssetLibrary.make_directory(asset_dir)
-
-        path = self.filepath_from_context(context)
-        libpath = path.replace(".fbx", ".json")
-
+    def _load_from_json(
+        self, libpath, path, asset_dir, asset_name, hierarchy_dir
+    ):
         with open(libpath, "r") as fp:
             data = json.load(fp)
 
@@ -222,6 +167,132 @@ class AnimationFBXLoader(plugin.Loader):
                     for s in sections:
                         s.params.set_editor_property('animation', animation)
 
+    def _load_standalone_animation(
+        self, path, asset_dir, asset_name, version_id
+    ):
+        selection = unreal.EditorUtilityLibrary.get_selected_assets()
+        skeleton = None
+        if selection:
+            skeleton = selection[0]
+        else:
+            # If no skeleton is selected, we try to find the skeleton by
+            # checking linked rigs.
+            project_name = get_current_project_name()
+            server = ayon_api.get_server_api_connection()
+
+            v_links = server.get_version_links(
+                project_name, version_id=version_id)
+            entities = [v_link["entityId"] for v_link in v_links]
+            linked_versions = list(server.get_versions(project_name, entities))
+
+            rigs = [
+                version["id"] for version in linked_versions
+                if "rig" in version["attrib"]["families"]]
+
+            containers = unreal_pipeline.ls()
+
+            ar = unreal.AssetRegistryHelpers.get_asset_registry()
+
+            for container in containers:
+                if container["representation"] in rigs:
+                    namespace = container["namespace"]
+
+                    _filter = unreal.ARFilter(
+                        class_names=["Skeleton"],
+                        package_paths=[namespace],
+                        recursive_paths=False)
+                    skeletons = ar.get_assets(_filter)
+
+                    if skeletons:
+                        skeleton = skeletons[0].get_asset()
+                        break
+
+        if not skeleton:
+            raise ValueError("No skeleton found.")
+
+        if skeleton.get_class() != unreal.Skeleton.static_class():
+            raise ValueError("Selected asset is not a skeleton.")
+
+        self._import_animation(
+            path, asset_dir, asset_name, skeleton, True)
+
+    def load(self, context, name, namespace, options=None):
+        """
+        Load and containerise representation into Content Browser.
+
+        This is two step process. First, import FBX to temporary path and
+        then call `containerise()` on it - this moves all content to new
+        directory and then it will create AssetContainer there and imprint it
+        with metadata. This will mark this path as container.
+
+        Args:
+            context (dict): application context
+            name (str): Product name
+            namespace (str): in Unreal this is basically path to container.
+                             This is not passed here, so namespace is set
+                             by `containerise()` because only then we know
+                             real path.
+            data (dict): Those would be data to be imprinted. This is not used
+                         now, data are imprinted by `containerise()`.
+
+        Returns:
+            list(str): list of container content
+        """
+        # Create directory for asset and Ayon container
+        root = "/Game/Ayon"
+        folder_path = context["folder"]["path"]
+        hierarchy = folder_path.lstrip("/").split("/")
+        folder_name = hierarchy.pop(-1)
+        product_type = context["product"]["productType"]
+
+        suffix = "_CON"
+        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
+        tools = unreal.AssetToolsHelpers().get_asset_tools()
+        asset_dir, container_name = tools.create_unique_asset_name(
+            f"{root}/Animations/{folder_name}/{name}", suffix="")
+
+        path = self.filepath_from_context(context)
+        libpath = path.replace(".fbx", ".json")
+
+        master_level = None
+
+        # check if json file exists.
+        if os.path.exists(libpath):
+            ar = unreal.AssetRegistryHelpers.get_asset_registry()
+
+            _filter = unreal.ARFilter(
+                class_names=["World"],
+                package_paths=[f"{root}/{hierarchy[0]}"],
+                recursive_paths=False)
+            levels = ar.get_assets(_filter)
+            master_level = levels[0].get_asset().get_path_name()
+
+            hierarchy_dir = root
+            for h in hierarchy:
+                hierarchy_dir = f"{hierarchy_dir}/{h}"
+            hierarchy_dir = f"{hierarchy_dir}/{folder_name}"
+
+            _filter = unreal.ARFilter(
+                class_names=["World"],
+                package_paths=[f"{hierarchy_dir}/"],
+                recursive_paths=True)
+            levels = ar.get_assets(_filter)
+            level = levels[0].get_asset().get_path_name()
+
+            unreal.EditorLevelLibrary.save_all_dirty_levels()
+            unreal.EditorLevelLibrary.load_level(level)
+
+            container_name += suffix
+
+            EditorAssetLibrary.make_directory(asset_dir)
+
+            self._load_from_json(
+                libpath, path, asset_dir, asset_name, hierarchy_dir)
+        else:
+            version_id = context["representation"]["versionId"]
+            self._load_standalone_animation(
+                path, asset_dir, asset_name, version_id)
+
         # Create Asset Container
         unreal_pipeline.create_container(
             container=container_name, path=asset_dir)
@@ -249,64 +320,23 @@ class AnimationFBXLoader(plugin.Loader):
         for a in imported_content:
             EditorAssetLibrary.save_asset(a)
 
-        unreal.EditorLevelLibrary.save_current_level()
-        unreal.EditorLevelLibrary.load_level(master_level)
+        if master_level:
+            unreal.EditorLevelLibrary.save_current_level()
+            unreal.EditorLevelLibrary.load_level(master_level)
 
     def update(self, container, context):
         repre_entity = context["representation"]
         folder_name = container["asset_name"]
         source_path = get_representation_path(repre_entity)
-        folder_entity = get_current_folder_entity(fields=["attrib.fps"])
         destination_path = container["namespace"]
-
-        task = unreal.AssetImportTask()
-        task.options = unreal.FbxImportUI()
-
-        task.set_editor_property('filename', source_path)
-        task.set_editor_property('destination_path', destination_path)
-        # strip suffix
-        task.set_editor_property('destination_name', folder_name)
-        task.set_editor_property('replace_existing', True)
-        task.set_editor_property('automated', True)
-        task.set_editor_property('save', True)
-
-        # set import options here
-        task.options.set_editor_property(
-            'automated_import_should_detect_type', False)
-        task.options.set_editor_property(
-            'original_import_type', unreal.FBXImportType.FBXIT_SKELETAL_MESH)
-        task.options.set_editor_property(
-            'mesh_type_to_import', unreal.FBXImportType.FBXIT_ANIMATION)
-        task.options.set_editor_property('import_mesh', False)
-        task.options.set_editor_property('import_animations', True)
-        task.options.set_editor_property('override_full_name', True)
-
-        task.options.anim_sequence_import_data.set_editor_property(
-            'animation_length',
-            unreal.FBXAnimationLengthImportType.FBXALIT_EXPORTED_TIME
-        )
-        task.options.anim_sequence_import_data.set_editor_property(
-            'import_meshes_in_bone_hierarchy', False)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'use_default_sample_rate', False)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'custom_sample_rate', folder_entity.get("attrib", {}).get("fps"))
-        task.options.anim_sequence_import_data.set_editor_property(
-            'import_custom_attribute', True)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'import_bone_tracks', True)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'remove_redundant_keys', False)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'convert_scene', True)
 
         skeletal_mesh = EditorAssetLibrary.load_asset(
             container.get('namespace') + "/" + container.get('asset_name'))
         skeleton = skeletal_mesh.get_editor_property('skeleton')
-        task.options.set_editor_property('skeleton', skeleton)
 
-        # do import fbx and replace existing data
-        unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+        self._import_animation(
+            source_path, destination_path, folder_name, skeleton, True)
+
         container_path = f'{container["namespace"]}/{container["objectName"]}'
         # update metadata
         unreal_pipeline.imprint(


### PR DESCRIPTION
> [!NOTE]
> This is port of https://github.com/ynput/ayon-core/pull/581 from ayon-core. For comments and review notes, please have a look at the conversation in the original PR.

## Changelog Description
Implemented a standalone loader for animation that do not require a layout to be loaded first.

## Additional info
Loader for Animation in Unreal is heavily based on the original solution using Blender and Unreal. Animation published from Maya doesn't have that layout json and so loading such animation will fail.