### PR TITLE
Fix extra comma in generate_sequence

### DIFF
--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -601,7 +601,7 @@ def generate_sequence(h, h_dir):
 
     project_name = get_current_project_name()
     # TODO Fix this does not return folder path
-    folder_path = h_dir.split('/')[-1],
+    folder_path = h_dir.split('/')[-1]
     folder_entity = ayon_api.get_folder_by_path(
         project_name,
         folder_path,


### PR DESCRIPTION
There was an extra comma in `generate_sequence` that blocked any loader that needs to use that function.

## Test notes
Try loading a layout. It should work fine.