### PR TITLE
Add `staticMesh` product type to loader plugin

### DIFF
--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -69,12 +69,13 @@ class LayoutLoader(plugin.Loader):
         name = ""
         if family == 'rig':
             name = "SkeletalMeshFBXLoader"
-        elif family == 'model':
+        elif family in ['model', 'staticMesh']:
             name = "StaticMeshFBXLoader"
         elif family == 'camera':
             name = "CameraLoader"
 
         if name == "":
+
             return None
 
         for loader in loaders:
@@ -88,7 +89,7 @@ class LayoutLoader(plugin.Loader):
         name = ""
         if family == 'rig':
             name = "SkeletalMeshAlembicLoader"
-        elif family == 'model':
+        elif family in ['model', 'staticMesh']:
             name = "StaticMeshAlembicLoader"
 
         if name == "":
@@ -387,7 +388,9 @@ class LayoutLoader(plugin.Loader):
 
                 if not loader:
                     self.log.error(
-                        f"No valid loader found for {repre_id}")
+                        f"No valid loader found for {repre_id} "
+                        f"({repr_format}) "
+                        f"{product_type}")
                     continue
 
                 options = {
@@ -427,7 +430,7 @@ class LayoutLoader(plugin.Loader):
 
                     actors = []
 
-                    if product_type == 'model':
+                    if product_type in ['model', 'staticMesh']:
                         actors, _ = self._process_family(
                             assets, 'StaticMesh', transform, basis,
                             sequence, inst
@@ -489,7 +492,7 @@ class LayoutLoader(plugin.Loader):
                 asset_container.get_asset(), "family")
             assets = EditorAssetLibrary.list_assets(
                 str(package_path), recursive=False)
-            if family == 'model':
+            if family in ['model', 'staticMesh']:
                 self._remove_family(
                     assets, static_meshes_comp, 'StaticMesh', 'static_mesh')
             elif family == 'rig':

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -67,7 +67,7 @@ class LayoutLoader(plugin.Loader):
     @staticmethod
     def _get_fbx_loader(loaders, family):
         name = ""
-        if family == 'rig':
+        if family in ['rig', 'skeletalMesh']:
             name = "SkeletalMeshFBXLoader"
         elif family in ['model', 'staticMesh']:
             name = "StaticMeshFBXLoader"
@@ -87,7 +87,7 @@ class LayoutLoader(plugin.Loader):
     @staticmethod
     def _get_abc_loader(loaders, family):
         name = ""
-        if family == 'rig':
+        if family in ['rig', 'skeletalMesh']:
             name = "SkeletalMeshAlembicLoader"
         elif family in ['model', 'staticMesh']:
             name = "StaticMeshAlembicLoader"
@@ -435,7 +435,7 @@ class LayoutLoader(plugin.Loader):
                             assets, 'StaticMesh', transform, basis,
                             sequence, inst
                         )
-                    elif product_type == 'rig':
+                    elif product_type in ['rig', 'skeletalMesh']:
                         actors, bindings = self._process_family(
                             assets, 'SkeletalMesh', transform, basis,
                             sequence, inst
@@ -495,7 +495,7 @@ class LayoutLoader(plugin.Loader):
             if family in ['model', 'staticMesh']:
                 self._remove_family(
                     assets, static_meshes_comp, 'StaticMesh', 'static_mesh')
-            elif family == 'rig':
+            elif family in ['rig', 'skeletalMesh']:
                 self._remove_family(
                     assets, skel_meshes_comp, 'SkeletalMesh', 'skeletal_mesh')
 


### PR DESCRIPTION
## Enhancement

Layout in Unreal supported just `rig` and `model` product types. This is adding also `staticMesh` and `skeletonMesh`.

## Testing

- Publish `skeletalMesh` and `staticMesh` products
- Create Layout with them and publish it
- Load it in Unreal


### TODO:

- [x] add `staticMesh`
- [x] add `skeletalMesh`