### PR TITLE
Local Rendering Bug Fix and add backward compatibility for deprecated function in render creator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "client/ayon_unreal/integration"]
 	path = client/ayon_unreal/integration
 	url = https://github.com/ynput/ayon-unreal-plugin.git
+[submodule "ayon-unreal-plugin"]
+	path = ayon-unreal-plugin
+	url = https://github.com/ynput/ayon-unreal-plugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "client/ayon_unreal/integration"]
 	path = client/ayon_unreal/integration
 	url = https://github.com/ynput/ayon-unreal-plugin.git
-[submodule "ayon-unreal-plugin"]
-	path = ayon-unreal-plugin
-	url = https://github.com/ynput/ayon-unreal-plugin.git

--- a/client/ayon_unreal/api/rendering.py
+++ b/client/ayon_unreal/api/rendering.py
@@ -97,6 +97,7 @@ def start_rendering():
 
     for i in inst_data:
         sequence = ar.get_asset_by_object_path(i["sequence"]).get_asset()
+
         sequences = [{
             "sequence": sequence,
             "output": f"{i['output']}",
@@ -195,10 +196,3 @@ def start_rendering():
         executor.on_individual_job_finished_delegate.add_callable_unique(
             _job_finish_callback)  # Only available on PIE Executor
         executor.execute(queue)
-
-
-
-
-# import unreal
-# les = unreal.get_editor_subsystem(unreal.LevelEditorSubsystem)
-# current_level = les.get_current_level()

--- a/client/ayon_unreal/plugins/create/create_render.py
+++ b/client/ayon_unreal/plugins/create/create_render.py
@@ -74,12 +74,19 @@ class CreateRender(UnrealAssetCreator):
         unreal.EditorAssetLibrary.save_asset(seq.get_path_name())
 
         # Create the master level
+        curr_level = None
         if UNREAL_VERSION.major >= 5:
-            curr_level = unreal.LevelEditorSubsystem().get_current_level()
+            if UNREAL_VERSION.minor >= 3:
+                les = unreal.get_editor_subsystem(unreal.LevelEditorSubsystem)
+                curr_level = les.get_current_level()
+            else:
+                curr_level = unreal.LevelEditorSubsystem().get_current_level()
+
         else:
             world = unreal.EditorLevelLibrary.get_editor_world()
             levels = unreal.EditorLevelUtils.get_levels(world)
             curr_level = levels[0] if len(levels) else None
+
             if not curr_level:
                 raise RuntimeError("No level loaded.")
         curr_level_path = curr_level.get_outer().get_path_name()


### PR DESCRIPTION
### Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/11 where blackscreen is rendered.
- Instead of using the level created along with the instance, the local render function would always use the persistent level for rendering if the level from the render instance is not persistent
- This ticket adds the check on the selection for the instance data asset. If the users dont choose the instance data for rendering, it will show the popup menu.
- This ticket also adds new function to find the current level in render creator while some backward compatibility implemented for the deprecated functions in or after UE 5.3

### Additional Info
**We should think if checking and raising the error for the current level not being persistent, instead of using the current level when the master level is not persistent.**
- Build Addon with this branch

### Testing Notes
1. Install Addon
2. Launch Unreal
3. Select your render instance data asset, and click `Render...` in AYON popup menu

![image](https://github.com/ynput/ayon-unreal/assets/64118225/041bb8ad-5ba6-4461-aab5-cdc1cabab9c3)

4. If you haven't selected your render instance data asset, it will raise error and show popup message.
5. Once you selected your render instance data asset, and hit `Render...`, it should be rendering without blackscreen.