### PR TITLE
Add supports for material import in alembic loader

### DIFF
--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -74,9 +74,9 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             'import_type', unreal.AlembicImportType.SKELETAL)
 
         mat_settings.set_editor_property(
-            "create_materials", loaded_options.get("create_materials"))
+            "create_materials", bool(loaded_options.get("create_materials", False)))
         mat_settings.set_editor_property(
-            "find_materials", loaded_options.get("find_materials"))
+            "find_materials", bool(loaded_options.get("find_materials", False)))
 
         if not loaded_options.get("default_conversion"):
             conversion_settings = None

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -42,11 +42,15 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             BoolDef(
                 "create_materials",
                 label="Create Materials",
+                tooltip="Create materials according to found Face Set "
+                        "names (will not work without face sets)",
                 default=False
             ),
             BoolDef(
                 "find_materials",
                 label="Find Materials",
+                tooltip="Find materials according to found Face Set "
+                        "names (will not work without face sets)",
                 default=False
             )
         ]

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -12,7 +12,7 @@ from ayon_unreal.api.pipeline import (
     create_container,
     imprint,
 )
-from ayon_core.lib import EnumDef, BoolDef
+from ayon_core.lib import EnumDef
 import unreal  # noqa
 
 
@@ -39,15 +39,15 @@ class StaticMeshAlembicLoader(plugin.Loader):
                 },
                 default="maya"
             ),
-            BoolDef(
-                "create_materials",
-                label="Create Materials",
-                default=False
-            ),
-            BoolDef(
-                "find_materials",
-                label="Find Materials",
-                default=False
+            EnumDef(
+                "abc_material_settings",
+                label="Alembic Material Settings",
+                items={
+                    "no_material": "Do not apply materials",
+                    "create_materials": "Create matarials by face sets",
+                    "find_materials": "Search matching materials by face sets",
+                },
+                default="no_materials"
             )
         ]
 
@@ -72,10 +72,16 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         sm_settings.set_editor_property('merge_meshes', True)
 
-        mat_settings.set_editor_property(
-            "create_materials", bool(loaded_options.get("create_materials", False)))
-        mat_settings.set_editor_property(
-            "find_materials", bool(loaded_options.get("find_materials", False)))
+        if loaded_options.get("abc_material_settings") == "create_materials":
+            mat_settings.set_editor_property("create_materials", True)
+            mat_settings.set_editor_property("find_materials", False)
+        elif loaded_options.get("abc_material_settings") == "find_materials":
+            mat_settings.set_editor_property("create_materials", False)
+            mat_settings.set_editor_property("find_materials", True)
+        else:
+            mat_settings.set_editor_property("create_materials", False)
+            mat_settings.set_editor_property("find_materials", False)
+
 
         if not loaded_options.get("default_conversion"):
             conversion_settings = None
@@ -167,8 +173,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
         loaded_options = {
             "default_conversion": options.get("default_conversion", False),
             "abc_conversion_preset": options.get("abc_conversion_preset", "maya"),
-            "create_materials": options.get("abc_conversion_preset", False),
-            "find_materials": options.get("find_materials", False)
+            "abc_material_settings": options.get("abc_material_settings", "no_material"),
         }
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -73,9 +73,9 @@ class StaticMeshAlembicLoader(plugin.Loader):
         sm_settings.set_editor_property('merge_meshes', True)
 
         mat_settings.set_editor_property(
-            "create_materials", loaded_options.get("create_materials"))
+            "create_materials", bool(loaded_options.get("create_materials", False)))
         mat_settings.set_editor_property(
-            "find_materials", loaded_options.get("find_materials"))
+            "find_materials", bool(loaded_options.get("find_materials", False)))
 
         if not loaded_options.get("default_conversion"):
             conversion_settings = None


### PR DESCRIPTION
### Changelog Descriptions
This PR is to add support for creating/finding materials in alembic import.

### Additional Info
Extra support for #21 (we may not need this)
Please test along with this PR: https://github.com/ynput/ayon-maya/pull/37

### Testing Notes
1. Launch Maya
2. Create Model/Point Cache
3. Make sure the write face sets turned on
4. Publish
5. Loaded the model in Unreal
6. There should be multiple material slots if there are materials/shaders assigned.

