### PR TITLE
enhancement: allow project creation option

### DIFF
--- a/client/ayon_unreal/hooks/pre_workfile_preparation.py
+++ b/client/ayon_unreal/hooks/pre_workfile_preparation.py
@@ -232,9 +232,11 @@ class UnrealPrelaunchHook(PreLaunchHook):
         if not project_file.is_file():
 
             #Get project settings -> allow project creation
-            allow_project_creation = bool(get_project_settings(get_current_project_name()).get("unreal",{}).get("project_setup", {}).get("allow_project_creation", True))
-
-            if (allow_project_creation):
+            current_project = get_current_project_name()
+            unreal_settings = get_project_settings(project).get("unreal")
+            allow_project_creation = unreproject_setupal_settings["project_setup"].get(
+                    "allow_project_creation")
+            if allow_project_creation:
                 with tempfile.TemporaryDirectory() as temp_dir:
                     self.exec_ue_project_gen(engine_version,
                                              unreal_project_name,

--- a/client/ayon_unreal/hooks/pre_workfile_preparation.py
+++ b/client/ayon_unreal/hooks/pre_workfile_preparation.py
@@ -14,6 +14,8 @@ from ayon_applications import (
     ApplicationLaunchFailed,
     LaunchTypes,
 )
+from ayon_core.settings import get_project_settings
+from ayon_core.pipeline import get_current_project_name
 from ayon_core.pipeline.workfile import get_workfile_template_key
 import ayon_unreal.lib as unreal_lib
 from ayon_unreal.ue_workers import (
@@ -228,24 +230,36 @@ class UnrealPrelaunchHook(PreLaunchHook):
         project_file = project_path / unreal_project_filename
 
         if not project_file.is_file():
-            with tempfile.TemporaryDirectory() as temp_dir:
-                self.exec_ue_project_gen(engine_version,
-                                         unreal_project_name,
-                                         engine_path,
-                                         Path(temp_dir))
-                try:
-                    self.log.info((
-                        f"Moving from {temp_dir} to "
-                        f"{project_path.as_posix()}"
-                    ))
-                    shutil.copytree(
-                        temp_dir, project_path, dirs_exist_ok=True)
 
-                except shutil.Error as e:
-                    raise ApplicationLaunchFailed((
-                        f"{self.signature} Cannot copy directory {temp_dir} "
-                        f"to {project_path.as_posix()} - {e}"
-                    )) from e
+            #Get project settings -> allow project creation
+            allow_project_creation = bool(get_project_settings(get_current_project_name()).get("unreal",{}).get("project_setup", {}).get("allow_project_creation", True))
+
+            if (allow_project_creation):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    self.exec_ue_project_gen(engine_version,
+                                             unreal_project_name,
+                                             engine_path,
+                                             Path(temp_dir))
+                    try:
+                        self.log.info((
+                            f"Moving from {temp_dir} to "
+                            f"{project_path.as_posix()}"
+                        ))
+                        shutil.copytree(
+                            temp_dir, project_path, dirs_exist_ok=True)
+
+                    except shutil.Error as e:
+                        raise ApplicationLaunchFailed((
+                            f"{self.signature} Cannot copy directory {temp_dir} "
+                            f"to {project_path.as_posix()} - {e}"
+                        )) from e
+            else:
+                raise ApplicationLaunchFailed(
+                    f"Could not open project; Project file not found.\n\n"
+                    f"'{project_path.as_posix()}' \n\n"
+                    f"Please contact administrator.\n"
+                    f"Make sure the project is in the correct folder. Or enable 'allow project creation' in studio settings"
+                )
 
         self.launch_context.env["AYON_UNREAL_VERSION"] = engine_version
         # Append project file to launch arguments

--- a/client/ayon_unreal/hooks/pre_workfile_preparation.py
+++ b/client/ayon_unreal/hooks/pre_workfile_preparation.py
@@ -237,9 +237,9 @@ class UnrealPrelaunchHook(PreLaunchHook):
 
             #Get project settings -> allow project creation
             current_project = get_current_project_name()
-            unreal_settings = get_project_settings(project).get("unreal")
-            allow_project_creation = unreproject_setupal_settings["project_setup"].get(
-                    "allow_project_creation")
+            unreal_settings = get_project_settings(current_project).get("unreal")
+            allow_project_creation = unreal_settings["project_setup"].get(
+            "allow_project_creation")
             if allow_project_creation:
                 with tempfile.TemporaryDirectory() as temp_dir:
                     self.exec_ue_project_gen(engine_version,

--- a/server/settings.py
+++ b/server/settings.py
@@ -4,6 +4,11 @@ from .imageio import UnrealImageIOModel
 
 
 class ProjectSetup(BaseSettingsModel):
+    allow_project_creation: bool = SettingsField(
+        True,
+        title="Allow project creation",
+        description="Whether to create a new project when none is found. Disable when using external source controll (Perforce)"
+    )
     dev_mode: bool = SettingsField(
         False,
         title="Dev mode"


### PR DESCRIPTION
+ Added option in studio settings to allow/disallow project creation for artists
+ Added functionality to project creation

This is usefull when working with source controll like perforce. This way artists dont accidentally create duplicate projects that can't be merged after. Default state is 'enabled' so that it wont change anything when not specificly set to false.