### PR TITLE
Fix the incorrect sequence path when using pre-hierarchy for render creator

### DIFF
--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -802,3 +802,33 @@ def maintained_selection():
         yield
     finally:
         pass
+
+
+def get_sequence(files):
+    """Get sequence from filename.
+
+    This will only return files if they exist on disk as it tries
+    to collect the sequence using the filename pattern and searching
+    for them on disk.
+
+    Supports negative frame ranges like -001, 0000, 0001 and -0001,
+    0000, 0001.
+
+    Arguments:
+        files (str): List of files
+
+    Returns:
+        Optional[list[str]]: file sequence.
+
+    """
+    collections, _remainder = clique.assemble(
+        files,
+        patterns=[clique.PATTERNS["frames"]],
+        minimum_items=1)
+
+    if len(collections) > 1:
+        raise ValueError(
+            f"Multiple collections found for {collections}. "
+            "This is a bug.")
+
+    return [os.path.basename(filename) for filename in collections[0]]

--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import json
+import clique
 import logging
 from typing import List
 from contextlib import contextmanager

--- a/client/ayon_unreal/plugins/create/create_render.py
+++ b/client/ayon_unreal/plugins/create/create_render.py
@@ -135,6 +135,7 @@ class CreateRender(UnrealAssetCreator):
         for sel in selection:
             selected_asset = ar.get_asset_by_object_path(sel).get_asset()
             selected_asset_path = selected_asset.get_path_name()
+            unreal.log("selected_asset_path")
 
             # Check if the selected asset is a level sequence asset.
             if selected_asset.get_class().get_name() != "LevelSequence":
@@ -149,9 +150,9 @@ class CreateRender(UnrealAssetCreator):
                 # "/Game/OpenPype/" and then we split the path by "/".
                 sel_path = selected_asset_path
                 asset_name = sel_path.replace(
-                    "/Game/Ayon/", "").split("/")[0]
+                    "/Game/Ayon/Sequences/", "").split("/")[0]
 
-                search_path = f"/Game/Ayon/{asset_name}"
+                search_path = f"/Game/Ayon/Sequences/{asset_name}"
             else:
                 search_path = Path(selected_asset_path).parent.as_posix()
 
@@ -163,8 +164,8 @@ class CreateRender(UnrealAssetCreator):
                     package_paths=[search_path],
                     recursive_paths=False)
                 sequences = ar.get_assets(ar_filter)
-                master_seq = sequences[0].get_asset().get_path_name()
                 master_seq_obj = sequences[0].get_asset()
+                master_seq = master_seq_obj.get_path_name()
                 ar_filter = unreal.ARFilter(
                     class_names=["World"],
                     package_paths=[search_path],

--- a/client/ayon_unreal/plugins/create/create_render.py
+++ b/client/ayon_unreal/plugins/create/create_render.py
@@ -135,7 +135,6 @@ class CreateRender(UnrealAssetCreator):
         for sel in selection:
             selected_asset = ar.get_asset_by_object_path(sel).get_asset()
             selected_asset_path = selected_asset.get_path_name()
-            unreal.log("selected_asset_path")
 
             # Check if the selected asset is a level sequence asset.
             if selected_asset.get_class().get_name() != "LevelSequence":

--- a/client/ayon_unreal/plugins/create/create_render.py
+++ b/client/ayon_unreal/plugins/create/create_render.py
@@ -146,7 +146,7 @@ class CreateRender(UnrealAssetCreator):
                 # The asset name is the the third element of the path which
                 # contains the map.
                 # To take the asset name, we remove from the path the prefix
-                # "/Game/OpenPype/" and then we split the path by "/".
+                # "/Game/Ayon/" and then we split the path by "/".
                 sel_path = selected_asset_path
                 asset_name = sel_path.replace(
                     "/Game/Ayon/Sequences/", "").split("/")[0]

--- a/client/ayon_unreal/plugins/publish/collect_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/collect_render_instances.py
@@ -65,7 +65,7 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
 
                     new_data = new_instance.data
 
-                    new_data["folderPath"] = f"{s.get('output')}"
+                    new_data["folderPath"] = f"/{s.get('output')}"
                     new_data["setMembers"] = seq_name
                     new_data["productName"] = new_product_name
                     new_data["productType"] = product_type

--- a/client/ayon_unreal/plugins/publish/collect_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/collect_render_instances.py
@@ -65,7 +65,7 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
 
                     new_data = new_instance.data
 
-                    new_data["folderPath"] = f"/{s.get('output')}"
+                    new_data["folderPath"] = f"{s.get('output')}"
                     new_data["setMembers"] = seq_name
                     new_data["productName"] = new_product_name
                     new_data["productType"] = product_type

--- a/client/ayon_unreal/plugins/publish/collect_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/collect_render_instances.py
@@ -1,6 +1,4 @@
 import os
-import re
-import clique
 from pathlib import Path
 
 import unreal

--- a/client/ayon_unreal/plugins/publish/collect_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/collect_render_instances.py
@@ -65,7 +65,7 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
 
                     new_data = new_instance.data
 
-                    new_data["folderPath"] = f"/{s.get('output')}"
+                    new_data["folderPath"] = instance.context.data["folderPath"]
                     new_data["setMembers"] = seq_name
                     new_data["productName"] = new_product_name
                     new_data["productType"] = product_type
@@ -73,7 +73,7 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
                     new_data["families"] = [product_type, "review"]
                     new_data["parent"] = data.get("parent")
                     new_data["level"] = data.get("level")
-                    new_data["output"] = s.get('output')
+                    new_data["output"] = s['output']
                     new_data["fps"] = seq.get_display_rate().numerator
                     new_data["frameStart"] = int(s.get('frame_range')[0])
                     new_data["frameEnd"] = int(s.get('frame_range')[1])
@@ -116,3 +116,4 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
                         'tags': ['review']
                     }
                     new_instance.data["representations"].append(repr)
+

--- a/client/ayon_unreal/plugins/publish/collect_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/collect_render_instances.py
@@ -98,11 +98,10 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
                     render_dir = f"{root}/{project}/{s.get('output')}"
                     render_path = Path(render_dir)
                     self.log.debug(f"Collecting render path: {render_path}")
-                    image_format = None
                     frames = [str(x) for x in render_path.iterdir() if x.is_file()]
-                    frames = get_sequence(frames)
-                    for x in frames:
-                        image_format = os.path.splitext(x)[-1].lstrip(".")
+                    frames = pipeline.get_sequence(frames)
+                    image_format = next((os.path.splitext(x)[-1].lstrip(".")
+                                         for x in frames), "exr")
 
                     if "representations" not in new_instance.data:
                         new_instance.data["representations"] = []
@@ -117,33 +116,3 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
                         'tags': ['review']
                     }
                     new_instance.data["representations"].append(repr)
-
-
-def get_sequence(files):
-    """Get sequence from filename.
-
-    This will only return files if they exist on disk as it tries
-    to collect the sequence using the filename pattern and searching
-    for them on disk.
-
-    Supports negative frame ranges like -001, 0000, 0001 and -0001,
-    0000, 0001.
-
-    Arguments:
-        files (str): List of files
-
-    Returns:
-        Optional[list[str]]: file sequence.
-
-    """
-    collections, _remainder = clique.assemble(
-        files,
-        patterns=[clique.PATTERNS["frames"]],
-        minimum_items=1)
-
-    if len(collections) > 1:
-        raise ValueError(
-            f"Multiple collections found for {collections}. "
-            "This is a bug.")
-
-    return [os.path.basename(filename) for filename in collections[0]]

--- a/client/ayon_unreal/plugins/publish/collect_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/collect_render_instances.py
@@ -94,12 +94,14 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
 
                     render_dir = f"{root}/{project}/{s.get('output')}"
                     render_path = Path(render_dir)
+                    self.log.debug(render_path)
 
                     frames = []
-
+                    image_format = None
                     for x in render_path.iterdir():
-                        if x.is_file() and x.suffix == '.png':
+                        if x.is_file():
                             frames.append(str(x.name))
+                            image_format = x.suffix.lstrip(".")
 
                     if "representations" not in new_instance.data:
                         new_instance.data["representations"] = []
@@ -107,8 +109,8 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
                     repr = {
                         'frameStart': instance.data["frameStart"],
                         'frameEnd': instance.data["frameEnd"],
-                        'name': 'png',
-                        'ext': 'png',
+                        'name': image_format,
+                        'ext': image_format,
                         'files': frames,
                         'stagingDir': render_dir,
                         'tags': ['review']

--- a/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
+++ b/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
@@ -73,8 +73,8 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin,
                 frames = frames[1:]
 
             current_range = (frames[0], frames[-1])
-            required_range = (folder_attributes.get("clipIn", 1),
-                              folder_attributes.get("clipOut", 1))
+            required_range = (folder_attributes.get("clipIn"),
+                              folder_attributes.get("clipOut"))
 
             if current_range != required_range:
                 raise PublishValidationError(

--- a/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
+++ b/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
@@ -1,6 +1,5 @@
 import clique
 import os
-import re
 from ayon_core.pipeline import (
     OptionalPyblishPluginMixin
 )
@@ -44,12 +43,10 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin,
                 _, ext = os.path.splitext(repr_files[0])
             elif not ext.startswith("."):
                 ext = ".{}".format(ext)
-            pattern = r"\D?(?P<index>(?P<padding>0*)\d+){}$".format(
-                re.escape(ext))
-            patterns = [pattern]
 
             collections, remainder = clique.assemble(
-                repr["files"], minimum_items=1, patterns=patterns)
+                repr["files"], minimum_items=1,
+                patterns=[clique.PATTERNS['frames']])
 
             if remainder:
                 raise PublishValidationError(

--- a/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
+++ b/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
@@ -73,8 +73,8 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin,
                 frames = frames[1:]
 
             current_range = (frames[0], frames[-1])
-            required_range = (folder_attributes["clipIn"],
-                              folder_attributes["clipOut"])
+            required_range = (folder_attributes.get("clipIn", 1),
+                              folder_attributes.get("clipOut", 1))
 
             if current_range != required_range:
                 raise PublishValidationError(

--- a/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
+++ b/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
@@ -1,12 +1,15 @@
 import clique
 import os
 import re
-
+from ayon_core.pipeline import (
+    OptionalPyblishPluginMixin
+)
 import pyblish.api
 from ayon_core.pipeline.publish import PublishValidationError
 
 
-class ValidateSequenceFrames(pyblish.api.InstancePlugin):
+class ValidateSequenceFrames(pyblish.api.InstancePlugin,
+                             OptionalPyblishPluginMixin):
     """Ensure the sequence of frames is complete
 
     The files found in the folder are checked against the frameStart and
@@ -21,6 +24,10 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin):
     optional = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            self.log.debug("Skipping Validate Frame Range...")
+            return
+
         representations = instance.data.get("representations")
         folder_attributes = (
             instance.data

--- a/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
+++ b/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
@@ -30,7 +30,7 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin,
         representations = instance.data.get("representations")
 
         folder_attributes = (
-            instance.context.data
+            instance.data
             .get("folderEntity", {})
             .get("attrib", {})
         )

--- a/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
+++ b/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
@@ -31,7 +31,7 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin,
 
         folder_attributes = (
             instance.context.data
-            .get("taskEntity", {})
+            .get("folderEntity", {})
             .get("attrib", {})
         )
         for repr in representations:

--- a/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
+++ b/client/ayon_unreal/plugins/publish/validate_sequence_frames.py
@@ -28,9 +28,10 @@ class ValidateSequenceFrames(pyblish.api.InstancePlugin,
             return
 
         representations = instance.data.get("representations")
+
         folder_attributes = (
-            instance.data
-            .get("folderEntity", {})
+            instance.context.data
+            .get("taskEntity", {})
             .get("attrib", {})
         )
         for repr in representations:


### PR DESCRIPTION
## Changelog Description
When we create render instance with pre-hierarchy options enabled, it will raise the error and the system can't manage to find the correct path. This PR is to fix it.


## Additional info
We should allow user settings for the sequences path
Resolve #58 

## Testing notes:

1. Create some level sequences inside `/Game/Ayon/Sequences/`
2. Create Render Instance with pre-hierarchy
3. Should not be error out

Also testing the steps below: 
1. Produce any rendered frames via ```AYON>Render``` (by render instance)
2. Use "Publish" with that render
3. Publishing fails on integration part
