### PR TITLE
UnrealAlembicPointCacheLoader/SkeletalMeshLoader: Align the loaded frame range to db

### DIFF
--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -223,11 +223,6 @@ class AnimationAlembicLoader(plugin.Loader):
         # Create directory for folder and Ayon container
         suffix = "_CON"
         source_path = get_representation_path(repre_entity)
-        loaded_options = {
-            "abc_conversion_preset": self.abc_conversion_preset,
-            "frameStart": int(container.get("frameStart", "1")),
-            "frameEnd": int(container.get("frameEnd", "1"))
-        }
 
         ext = os.path.splitext(source_path)[-1].lstrip(".")
         asset_name = product_name
@@ -247,7 +242,9 @@ class AnimationAlembicLoader(plugin.Loader):
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             loaded_options = {
-                    "abc_conversion_preset": self.abc_conversion_preset
+                "abc_conversion_preset": self.abc_conversion_preset,
+                "frameStart": int(container.get("frameStart", "1")),
+                "frameEnd": int(container.get("frameEnd", "1"))
             }
             self.import_and_containerize(
                 source_path, asset_dir, asset_name, container_name, loaded_options

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -181,8 +181,8 @@ class AnimationAlembicLoader(plugin.Loader):
         destination_path = container["namespace"]
         loaded_options = {
             "abc_conversion_preset": self.abc_conversion_preset,
-            "frameStart": container.get("frameStart", 1),
-            "frameEnd": container.get("frameEnd", 1)
+            "frameStart": int(container.get("frameStart", "1")),
+            "frameEnd": int(container.get("frameEnd", "1"))
         }
         task = self.get_task(
             source_path, destination_path, folder_name, True, loaded_options

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -140,7 +140,6 @@ class AnimationAlembicLoader(plugin.Loader):
         """
 
         # Create directory for asset and ayon container
-        root = unreal_pipeline.AYON_ASSET_DIR
         folder_entity = context["folder"]
         folder_name = context["folder"]["name"]
         folder_path = context["folder"]["path"]

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -21,6 +21,7 @@ class AnimationAlembicLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
     abc_conversion_preset = "maya"
+    root = unreal_pipeline.AYON_ASSET_DIR
 
     @classmethod
     def apply_settings(cls, project_settings):

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -47,6 +47,8 @@ class PointCacheAlembicLoader(plugin.Loader):
 
         options.set_editor_property(
             'import_type', unreal.AlembicImportType.GEOMETRY_CACHE)
+        options.sampling_settings.frame_start = frame_start
+        options.sampling_settings.frame_end = frame_end
 
         gc_settings.set_editor_property('flatten_tracks', False)
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -72,8 +72,8 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
         options.set_editor_property(
             'import_type', unreal.AlembicImportType.SKELETAL)
-        options.sampling_settings.frame_start = loaded_options.get("frameStart", 1)
-        options.sampling_settings.frame_end = loaded_options.get("frameEnd", 1)
+        options.sampling_settings.frame_start = loaded_options.get("frameStart")
+        options.sampling_settings.frame_end = loaded_options.get("frameEnd")
 
         if loaded_options.get("abc_material_settings") == "create_materials":
             mat_settings.set_editor_property("create_materials", True)

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -72,6 +72,8 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
         options.set_editor_property(
             'import_type', unreal.AlembicImportType.SKELETAL)
+        options.sampling_settings.frame_start = loaded_options.get("frameStart", 1)
+        options.sampling_settings.frame_end = loaded_options.get("frameEnd", 1)
 
         if loaded_options.get("abc_material_settings") == "create_materials":
             mat_settings.set_editor_property("create_materials", True)
@@ -95,6 +97,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
                     flip_u=False, flip_v=False,
                     rotation=[0.0, 0.0, 0.0],
                     scale=[1.0, 1.0, 1.0])
+
             options.conversion_settings = conversion_settings
 
             options.material_settings = mat_settings
@@ -159,8 +162,9 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             list(str): list of container content
         """
         # Create directory for asset and ayon container
-        folder_path = context["folder"]["path"]
-        folder_name = context["folder"]["name"]
+        folder_entity = context["folder"]
+        folder_path = folder_entity["path"]
+        folder_name = folder_entity["name"]
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         version = context["version"]["version"]
@@ -173,7 +177,9 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         loaded_options = {
             "default_conversion": options.get("default_conversion", False),
             "abc_conversion_preset": options.get("abc_conversion_preset", "maya"),
-            "abc_material_settings": options.get("abc_material_settings", "no_material")
+            "abc_material_settings": options.get("abc_material_settings", "no_material"),
+            "frameStart": folder_entity["attrib"]["frameStart"],
+            "frameEnd": folder_entity["attrib"]["frameEnd"]
         }
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/24 and also align to load skeletalmesh according to db.

## Additional info
n/a

## Testing notes:

1. Launch Unreal
2. Load PointCache with `Import Alembic Point Cache` and `Import Alembic Skeletal Mesh`
3. Frame range should be correct
