### PR TITLE
Ingest all fbx/abc assets into the project_name folder within ayon/assets folder hierarchy 

### DIFF
--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -72,6 +72,7 @@ class AnimationAlembicLoader(plugin.Loader):
         root = unreal_pipeline.AYON_ASSET_DIR
         folder_name = context["folder"]["name"]
         folder_path = context["folder"]["path"]
+        project_name = context["project"]["name"]
         product_type = context["product"]["productType"]
         suffix = "_CON"
         if folder_name:
@@ -87,7 +88,7 @@ class AnimationAlembicLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/{folder_name}/{name_version}", suffix="")
+            f"{root}/{project_name}/{folder_name}/{name_version}", suffix="")
 
         container_name += suffix
 

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -249,7 +249,9 @@ class AnimationFBXLoader(plugin.Loader):
             list(str): list of container content
         """
         # Create directory for asset and Ayon container
-        root = "/Game/Ayon"
+        root = unreal_pipeline.AYON_ASSET_DIR
+        project_name = context["project"]["name"]
+        root = f"{root}/{project_name}"
         folder_path = context["folder"]["path"]
         hierarchy = folder_path.lstrip("/").split("/")
         folder_name = hierarchy.pop(-1)

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -130,6 +130,7 @@ class PointCacheAlembicLoader(plugin.Loader):
         """
         # Create directory for asset and Ayon container
         folder_entity = context["folder"]
+        project_name = context["project"]["name"]
         folder_path = folder_entity["path"]
         folder_name = folder_entity["name"]
         folder_attributes = folder_entity["attrib"]
@@ -145,7 +146,7 @@ class PointCacheAlembicLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{project_name}/{folder_name}/{name_version}", suffix="")
 
         container_name += suffix
 
@@ -188,6 +189,7 @@ class PointCacheAlembicLoader(plugin.Loader):
         # Create directory for folder and Ayon container
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
+        project_name = context["project"]["name"]
         product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         version = context["version"]["version"]
@@ -205,7 +207,7 @@ class PointCacheAlembicLoader(plugin.Loader):
             name_version = f"{product_name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{project_name}/{folder_name}/{name_version}", suffix="")
 
         container_name += suffix
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -161,6 +161,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         # Create directory for asset and ayon container
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
+        project_name = context["project"]["name"]
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         version = context["version"]["version"]
@@ -178,7 +179,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{project_name}/{folder_name}/{name_version}", suffix="")
 
         container_name += suffix
 
@@ -210,6 +211,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
     def update(self, container, context):
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
+        project_name = context["project"]["name"]
         product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         version = context["version"]["version"]
@@ -227,7 +229,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             name_version = f"{product_name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{project_name}/{folder_name}/{name_version}", suffix="")
 
         container_name += suffix
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -120,6 +120,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         """
         # Create directory for asset and Ayon container
         folder_name = context["folder"]["name"]
+        project_name = context["project"]["name"]
         product_type = context["product"]["productType"]
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
@@ -133,7 +134,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix=""
+            f"{self.root}/{project_name}/{folder_name}/{name_version}", suffix=""
         )
 
         container_name += suffix
@@ -165,6 +166,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
     def update(self, container, context):
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
+        project_name = context["project"]["name"]
         product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         version = context["version"]["version"]
@@ -182,7 +184,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
             name_version = f"{product_name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{project_name}/{folder_name}/{name_version}", suffix="")
 
         container_name += suffix
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -167,7 +167,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
         # Create directory for asset and Ayon container
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
-
+        project_name = context["project"]["name"]
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         version = context["version"]["version"]
@@ -185,7 +185,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{project_name}/{folder_name}/{name_version}", suffix="")
 
         container_name += suffix
 
@@ -217,6 +217,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
     def update(self, container, context):
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
+        project_name = context["project"]["name"]
         product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         repre_entity = context["representation"]
@@ -235,7 +236,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{project_name}/{folder_name}/{name_version}", suffix="")
 
         container_name += suffix
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -109,6 +109,7 @@ class StaticMeshFBXLoader(plugin.Loader):
         # Create directory for asset and Ayon container
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
+        project_name = context["project"]["name"]
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         version = context["version"]["version"]
@@ -120,7 +121,7 @@ class StaticMeshFBXLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix=""
+            f"{self.root}/{project_name}/{folder_name}/{name_version}", suffix=""
         )
 
         container_name += suffix
@@ -152,6 +153,7 @@ class StaticMeshFBXLoader(plugin.Loader):
     def update(self, container, context):
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
+        project_name = context["project"]["name"]
         product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         version = context["version"]["version"]
@@ -169,7 +171,7 @@ class StaticMeshFBXLoader(plugin.Loader):
             name_version = f"{product_name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{project_name}/{folder_name}/{name_version}", suffix="")
 
         container_name += suffix
 


### PR DESCRIPTION
## Changelog Description
May have resolved #38 
This PR is to align with the hierarchies of the publish folder.
The camera loader would also move to `/Ayon/Assets`

## Additional info
We need to think if we should place the loaded assets(such as uasset, layout, camera) into `/Ayon/Assets`


## Testing notes:

1. Launch Unreal
2. Load all the fbx assets
