### PR TITLE
add loaded asset extensions settings for layout loaders in unreal host

### DIFF
--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -338,7 +338,7 @@ class LayoutLoader(plugin.Loader):
         project_name = get_current_project_name()
         repre_entities = ayon_api.get_representations(
             project_name,
-            representation_names=repre_extension,
+            representation_names={repre_extension},
             version_ids=version_ids,
             fields={"id", "versionId", "name"}
         )

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -35,6 +35,7 @@ from ayon_unreal.api.pipeline import (
     imprint,
     ls,
 )
+from ayon_core.lib import EnumDef
 
 
 class LayoutLoader(plugin.Loader):
@@ -47,6 +48,32 @@ class LayoutLoader(plugin.Loader):
     icon = "code-fork"
     color = "orange"
     ASSET_ROOT = "/Game/Ayon"
+    loaded_assets_extension = "fbx"
+
+    @classmethod
+    def apply_settings(cls, project_settings):
+        super(LayoutLoader, cls).apply_settings(project_settings)
+
+        # Apply import settings
+        loaded_assets_extension = (
+            project_settings.get("unreal", {}).get("loaded_assets_extension", {})
+        )
+        if loaded_assets_extension:
+            cls.loaded_assets_extension = loaded_assets_extension
+
+    @classmethod
+    def get_options(cls, contexts):
+        return [
+            EnumDef(
+                "loaded_assets_extension",
+                label="Loaded Assets Extension",
+                items={
+                    "fbx": "fbx",
+                    "abc": "abc"
+                },
+                default=cls.loaded_assets_extension
+            )
+        ]
 
     def _get_asset_containers(self, path):
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
@@ -296,7 +323,7 @@ class LayoutLoader(plugin.Loader):
                     sec_params = section.get_editor_property('params')
                     sec_params.set_editor_property('animation', animation)
 
-    def _get_repre_entities_by_version_id(self, data):
+    def _get_repre_entities_by_version_id(self, data, repre_extension):
         version_ids = {
             element.get("version")
             for element in data
@@ -311,7 +338,7 @@ class LayoutLoader(plugin.Loader):
         project_name = get_current_project_name()
         repre_entities = ayon_api.get_representations(
             project_name,
-            representation_names={"fbx", "abc"},
+            representation_names=repre_extension,
             version_ids=version_ids,
             fields={"id", "versionId", "name"}
         )
@@ -320,7 +347,8 @@ class LayoutLoader(plugin.Loader):
             output[version_id].append(repre_entity)
         return output
 
-    def _process(self, lib_path, asset_dir, sequence, repr_loaded=None):
+    def _process(self, lib_path, asset_dir, sequence,
+                 repr_loaded=None, loaded_extension=None):
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
 
         with open(lib_path, "r") as fp:
@@ -340,7 +368,7 @@ class LayoutLoader(plugin.Loader):
         loaded_assets = []
 
         repre_entities_by_version_id = self._get_repre_entities_by_version_id(
-            data
+            data, loaded_extension
         )
         for element in data:
             repre_id = None
@@ -644,9 +672,11 @@ class LayoutLoader(plugin.Loader):
                     [level])
 
             EditorLevelLibrary.load_level(level)
-
+        extension = options.get(
+            "loaded_assets_extension", self.loaded_assets_extension)
         path = self.filepath_from_context(context)
-        loaded_assets = self._process(path, asset_dir, shot)
+        loaded_assets = self._process(
+            path, asset_dir, shot, loaded_extension=extension)
 
         for s in sequences:
             EditorAssetLibrary.save_asset(s.get_path_name())
@@ -759,7 +789,9 @@ class LayoutLoader(plugin.Loader):
 
         source_path = get_representation_path(repre_entity)
 
-        loaded_assets = self._process(source_path, asset_dir, sequence)
+        loaded_assets = self._process(
+            source_path, asset_dir, sequence,
+            loaded_extension=self.loaded_assets_extension)
 
         data = {
             "representation": repre_entity["id"],

--- a/server/settings.py
+++ b/server/settings.py
@@ -1,5 +1,4 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
-
 from .imageio import UnrealImageIOModel
 
 
@@ -19,6 +18,13 @@ def _render_format_enum():
     ]
 
 
+def _loaded_asset_enum():
+    return [
+        {"value": "fbx", "label": "fbx"},
+        {"value": "abc", "label": "abc"}
+    ]
+
+
 class UnrealSettings(BaseSettingsModel):
     imageio: UnrealImageIOModel = SettingsField(
         default_factory=UnrealImageIOModel,
@@ -31,6 +37,12 @@ class UnrealSettings(BaseSettingsModel):
     delete_unmatched_assets: bool = SettingsField(
         False,
         title="Delete assets that are not matched"
+    )
+    loaded_assets_extension: str = SettingsField(
+        "fbx",
+        title="Loaded Assets Extension",
+        enum_resolver=_loaded_asset_enum,
+        description="Extension for the loaded assets"
     )
     render_queue_path: str = SettingsField(
         "",
@@ -60,6 +72,7 @@ class UnrealSettings(BaseSettingsModel):
 DEFAULT_VALUES = {
     "level_sequences_for_layouts": True,
     "delete_unmatched_assets": False,
+    "loaded_assets_extension": "fbx",
     "render_queue_path": "/Game/Ayon/renderQueue",
     "render_config_path": "/Game/Ayon/DefaultMovieRenderQueueConfig.DefaultMovieRenderQueueConfig",
     "preroll_frames": 0,


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/6 in unreal

## Additional info
we need to resolve the maya part too once the load layout json implemented in maya


## Testing notes:

1. Build Unreal Addon with this branch
2. Set your preferred loaded extension in `ayon+settings://unreal/loaded_assets_extension`
![image](https://github.com/user-attachments/assets/d8e295c6-f96c-469a-9828-ceedd0979926)
3. Launch Unreal
4. Ayon -> Load
5. Click the memo icon in Load Layout(json)
![image](https://github.com/user-attachments/assets/83406e42-71c5-43c5-a871-09a7eab9cbfb)
6. Load your preferred loaded extension format (if you dont think the one you set in ayon server)
![image](https://github.com/user-attachments/assets/c1b3bb07-ba3f-456c-8f3a-950c9e8e526f)
7. Click "ok"