### PR TITLE
Loading animation asset from FBX animation loader should be in correct rotation

### DIFF
--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -71,6 +71,8 @@ class AnimationFBXLoader(plugin.Loader):
             'convert_scene', True)
         task.options.anim_sequence_import_data.set_editor_property(
             'force_front_x_axis', False)
+        task.options.anim_sequence_import_data.set_editor_property(
+            'import_rotation', unreal.Rotator(roll=90.0, pitch=0.0, yaw=0.0))
 
         unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
 


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/41

## Additional info
You should load your rig before loading animation asset from the fbx animation loader.


## Testing notes:

1. Launch Unreal
2. Load FBX animation
3. Place the asset as the actor
4. The actor should be at correct rotation
