### PR TITLE
Add extension as suffix when creating unique asset name

### DIFF
--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -85,16 +85,17 @@ class AnimationAlembicLoader(plugin.Loader):
         else:
             name_version = f"{name}_v{version:03d}"
 
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/{folder_name}/{name_version}", suffix="")
+            f"{root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             unreal.EditorAssetLibrary.make_directory(asset_dir)
 
-            path = self.filepath_from_context(context)
             task = self.get_task(path, asset_dir, asset_name, False)
 
             asset_tools = unreal.AssetToolsHelpers.get_asset_tools()

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -74,10 +74,12 @@ class AnimationAlembicLoader(plugin.Loader):
         folder_path = context["folder"]["path"]
         product_type = context["product"]["productType"]
         suffix = "_CON"
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         if folder_name:
-            asset_name = "{}_{}".format(folder_name, name)
+            asset_name = "{}_{}_{}".format(folder_name, name, ext)
         else:
-            asset_name = "{}".format(name)
+            asset_name = "{}_{}".format(name, ext)
         version = context["version"]["version"]
         # Check if version is hero version and use different name
         if version < 0:
@@ -85,8 +87,6 @@ class AnimationAlembicLoader(plugin.Loader):
         else:
             name_version = f"{name}_v{version:03d}"
 
-        path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{root}/{folder_name}/{name_version}", suffix=f"_{ext}")

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -258,12 +258,14 @@ class AnimationFBXLoader(plugin.Loader):
         product_type = context["product"]["productType"]
 
         suffix = "_CON"
+
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/Animations/{folder_name}/{name}", suffix="")
+            f"{root}/Animations/{folder_name}/{name}", suffix=f"_{ext}")
 
-        path = self.filepath_from_context(context)
         libpath = path.replace(".fbx", ".json")
 
         master_level = None

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -261,7 +261,7 @@ class AnimationFBXLoader(plugin.Loader):
 
         path = self.filepath_from_context(context)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
+        asset_name = f"{folder_name}_{name}_{ext}" if folder_name else f"{name}_{ext}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{root}/Animations/{folder_name}/{name}", suffix=f"_{ext}")

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -135,15 +135,15 @@ class PointCacheAlembicLoader(plugin.Loader):
         folder_attributes = folder_entity["attrib"]
 
         suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
+        asset_name = f"{folder_name}_{name}_{ext}" if folder_name else f"{name}_{ext}"
         version = context["version"]["version"]
         # Check if version is hero version and use different name
         if version < 0:
             name_version = f"{name}_hero"
         else:
             name_version = f"{name}_v{version:03d}"
-        path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
@@ -195,7 +195,9 @@ class PointCacheAlembicLoader(plugin.Loader):
         repre_entity = context["representation"]
 
         suffix = "_CON"
-        asset_name = product_name
+        path = get_representation_path(repre_entity)
+        ext = os.path.splitext(path)[-1].lstrip(".")
+        asset_name = f"{product_name}_{ext}"
         if folder_name:
             asset_name = f"{folder_name}_{product_name}"
 
@@ -204,8 +206,6 @@ class PointCacheAlembicLoader(plugin.Loader):
             name_version = f"{product_name}_hero"
         else:
             name_version = f"{product_name}_v{version:03d}"
-        path = get_representation_path(repre_entity)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -142,10 +142,11 @@ class PointCacheAlembicLoader(plugin.Loader):
             name_version = f"{name}_hero"
         else:
             name_version = f"{name}_v{version:03d}"
-
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 
@@ -203,9 +204,11 @@ class PointCacheAlembicLoader(plugin.Loader):
             name_version = f"{product_name}_hero"
         else:
             name_version = f"{product_name}_v{version:03d}"
+        path = get_representation_path(repre_entity)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 
@@ -213,8 +216,6 @@ class PointCacheAlembicLoader(plugin.Loader):
         frame_end = int(container.get("frame_end"))
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = get_representation_path(repre_entity)
-
             self.import_and_containerize(
                 path, asset_dir, asset_name, container_name,
                 frame_start, frame_end)

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -162,7 +162,9 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
         suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
+        asset_name = f"{folder_name}_{name}_{ext}" if folder_name else f"{name}_{ext}"
         version = context["version"]["version"]
         # Check if version is hero version and use different name
         if version < 0:
@@ -176,8 +178,6 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             "abc_material_settings": options.get("abc_material_settings", "no_material")
         }
 
-        path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
@@ -217,7 +217,9 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
         # Create directory for folder and Ayon container
         suffix = "_CON"
-        asset_name = product_name
+        path = get_representation_path(repre_entity)
+        ext = os.path.splitext(path)[-1].lstrip(".")
+        asset_name = f"{product_name}_{ext}"
         if folder_name:
             asset_name = f"{folder_name}_{product_name}"
         # Check if version is hero version and use different name
@@ -226,8 +228,6 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         else:
             name_version = f"{product_name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
-        path = get_representation_path(repre_entity)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -176,15 +176,15 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             "abc_material_settings": options.get("abc_material_settings", "no_material")
         }
 
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = self.filepath_from_context(context)
-
             self.import_and_containerize(path, asset_dir, asset_name,
                                          container_name, loaded_options)
 
@@ -226,13 +226,14 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         else:
             name_version = f"{product_name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
+        path = get_representation_path(repre_entity)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = get_representation_path(repre_entity)
             loaded_options = {"default_conversion": False}
             self.import_and_containerize(path, asset_dir, asset_name,
                                          container_name, loaded_options)

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -122,7 +122,9 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         folder_name = context["folder"]["name"]
         product_type = context["product"]["productType"]
         suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
+        asset_name = f"{folder_name}_{name}_{ext}" if folder_name else f"{name}_{ext}"
         version_entity = context["version"]
         # Check if version is hero version and use different name
         version = version_entity["version"]
@@ -132,8 +134,6 @@ class SkeletalMeshFBXLoader(plugin.Loader):
             name_version = f"{name}_v{version:03d}"
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
-        path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}"
         )
@@ -172,7 +172,9 @@ class SkeletalMeshFBXLoader(plugin.Loader):
 
         # Create directory for asset and Ayon container
         suffix = "_CON"
-        asset_name = product_name
+        path = get_representation_path(repre_entity)
+        ext = os.path.splitext(path)[-1].lstrip(".")
+        asset_name = f"{product_name}_{ext}"
         if folder_name:
             asset_name = f"{folder_name}_{product_name}"
         # Check if version is hero version and use different name
@@ -181,8 +183,6 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         else:
             name_version = f"{product_name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
-        path = get_representation_path(repre_entity)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -132,15 +132,15 @@ class SkeletalMeshFBXLoader(plugin.Loader):
             name_version = f"{name}_v{version:03d}"
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix=""
+            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}"
         )
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = self.filepath_from_context(context)
-
             self.import_and_containerize(
                 path, asset_dir, asset_name, container_name)
 
@@ -181,14 +181,14 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         else:
             name_version = f"{product_name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
+        path = get_representation_path(repre_entity)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = get_representation_path(repre_entity)
-
             self.import_and_containerize(
                 path, asset_dir, asset_name, container_name)
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -184,14 +184,14 @@ class StaticMeshAlembicLoader(plugin.Loader):
         }
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = self.filepath_from_context(context)
-
             self.import_and_containerize(path, asset_dir, asset_name,
                                          container_name, loaded_options)
 
@@ -234,13 +234,14 @@ class StaticMeshAlembicLoader(plugin.Loader):
             name_version = f"{product_name}_v{version:03d}"
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
+        path = get_representation_path(repre_entity)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = get_representation_path(repre_entity)
             loaded_options = {"default_conversion": False}
             self.import_and_containerize(path, asset_dir, asset_name,
                                          container_name, loaded_options)

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -169,7 +169,9 @@ class StaticMeshAlembicLoader(plugin.Loader):
         folder_name = context["folder"]["name"]
 
         suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
+        asset_name = f"{folder_name}_{name}_{ext}" if folder_name else f"{name}_{ext}"
         version = context["version"]["version"]
         # Check if version is hero version and use different name
         if version < 0:
@@ -184,8 +186,6 @@ class StaticMeshAlembicLoader(plugin.Loader):
         }
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
-        path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 
@@ -223,7 +223,9 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         # Create directory for asset and Ayon container
         suffix = "_CON"
-        asset_name = product_name
+        path = get_representation_path(repre_entity)
+        ext = os.path.splitext(path)[-1].lstrip(".")
+        asset_name = f"{product_name}_{ext}"
         if folder_name:
             asset_name = f"{folder_name}_{product_name}"
         version = context["version"]["version"]
@@ -234,8 +236,6 @@ class StaticMeshAlembicLoader(plugin.Loader):
             name_version = f"{product_name}_v{version:03d}"
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
-        path = get_representation_path(repre_entity)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -110,7 +110,9 @@ class StaticMeshFBXLoader(plugin.Loader):
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
         suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
+        asset_name = f"{folder_name}_{name}_{ext}" if folder_name else f"{name}_{ext}"
         version = context["version"]["version"]
         # Check if version is hero version and use different name
         if version < 0:
@@ -119,8 +121,6 @@ class StaticMeshFBXLoader(plugin.Loader):
             name_version = f"{name}_v{version:03d}"
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
-        path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}"
         )
@@ -159,7 +159,9 @@ class StaticMeshFBXLoader(plugin.Loader):
 
         # Create directory for asset and Ayon container
         suffix = "_CON"
-        asset_name = product_name
+        path = get_representation_path(repre_entity)
+        ext = os.path.splitext(path)[-1].lstrip(".")
+        asset_name = f"{product_name}_{ext}"
         if folder_name:
             asset_name = f"{folder_name}_{product_name}"
         # Check if version is hero version and use different name
@@ -168,8 +170,6 @@ class StaticMeshFBXLoader(plugin.Loader):
         else:
             name_version = f"{product_name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
-        path = get_representation_path(repre_entity)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -119,15 +119,15 @@ class StaticMeshFBXLoader(plugin.Loader):
             name_version = f"{name}_v{version:03d}"
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
+        path = self.filepath_from_context(context)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix=""
+            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}"
         )
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = self.filepath_from_context(context)
-
             self.import_and_containerize(
                 path, asset_dir, asset_name, container_name)
 
@@ -168,14 +168,14 @@ class StaticMeshFBXLoader(plugin.Loader):
         else:
             name_version = f"{product_name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
+        path = get_representation_path(repre_entity)
+        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix="")
+            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
-            path = get_representation_path(repre_entity)
-
             self.import_and_containerize(
                 path, asset_dir, asset_name, container_name)
 


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/49

## Additional info
Only implemented in the staticMesh, skeletalMesh, animation and geometry cache loader.
We should think if it is neccessary for other loaders too.

## Testing notes:

1. Launch Unreal
2. Load staticMesh, skeletalMesh, animation or geometry cache product
3. It should be located in `/Ayon/Assets/{folder_task_name}/{subset}_{version}_{ext}`
![image](https://github.com/user-attachments/assets/3c59b1f6-1645-41d4-b870-945fc1b96636)

