### PR TITLE
Supports for preset almebic conversion import in ayon settings

### DIFF
--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -2,6 +2,7 @@
 """Load Alembic Animation."""
 import os
 
+from ayon_core.lib import EnumDef
 from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
@@ -19,17 +20,49 @@ class AnimationAlembicLoader(plugin.Loader):
     representations = {"abc"}
     icon = "cube"
     color = "orange"
+    abc_conversion_preset = "maya"
 
-    def get_task(self, filename, asset_dir, asset_name, replace):
+    @classmethod
+    def apply_settings(cls, project_settings):
+        super(AnimationAlembicLoader, cls).apply_settings(project_settings)
+        # Apply import settings
+        unreal_settings = project_settings.get("unreal", {})
+        if unreal_settings.get("abc_conversion_preset", cls.abc_conversion_preset):
+            cls.abc_conversion_preset = unreal_settings.get(
+                "abc_conversion_preset", cls.abc_conversion_preset)
+
+    @classmethod
+    def get_options(cls, contexts):
+        return [
+            EnumDef(
+                "abc_conversion_preset",
+                label="Alembic Conversion Preset",
+                items={
+                    "custom": "custom",
+                    "maya": "maya"
+                },
+                default=cls.abc_conversion_preset
+            )
+        ]
+
+    def get_task(self, filename, asset_dir, asset_name, replace, loaded_options=None):
         task = unreal.AssetImportTask()
         options = unreal.AbcImportSettings()
         sm_settings = unreal.AbcStaticMeshSettings()
-        conversion_settings = unreal.AbcConversionSettings(
-            preset=unreal.AbcConversionPreset.CUSTOM,
-            flip_u=False, flip_v=False,
-            rotation=[0.0, 0.0, 0.0],
-            scale=[1.0, 1.0, -1.0])
+        conversion_settings = unreal.AbcConversionSettings()
+        abc_conversion_preset = loaded_options.get("abc_conversion_preset")
+        if abc_conversion_preset == "maya":
+            conversion_settings = unreal.AbcConversionSettings(
+                preset= unreal.AbcConversionPreset.MAYA)
+        else:
+            conversion_settings = unreal.AbcConversionSettings(
+                preset=unreal.AbcConversionPreset.CUSTOM,
+                flip_u=False, flip_v=False,
+                rotation=[0.0, 0.0, 0.0],
+                scale=[1.0, 1.0, 1.0])
 
+        options.sampling_settings.frame_start = loaded_options.get("frameStart")
+        options.sampling_settings.frame_end = loaded_options.get("frameEnd")
         task.set_editor_property('filename', filename)
         task.set_editor_property('destination_path', asset_dir)
         task.set_editor_property('destination_name', asset_name)
@@ -46,7 +79,7 @@ class AnimationAlembicLoader(plugin.Loader):
 
         return task
 
-    def load(self, context, name, namespace, data):
+    def load(self, context, name, namespace, options):
         """Load and containerise representation into Content Browser.
 
         This is two step process. First, import FBX to temporary path and
@@ -93,9 +126,12 @@ class AnimationAlembicLoader(plugin.Loader):
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             unreal.EditorAssetLibrary.make_directory(asset_dir)
-
+            loaded_options = {
+                "abc_conversion_preset": options.get(
+                    "abc_conversion_preset", self.abc_conversion_preset)
+            }
             path = self.filepath_from_context(context)
-            task = self.get_task(path, asset_dir, asset_name, False)
+            task = self.get_task(path, asset_dir, asset_name, False, loaded_options)
 
             asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
             asset_tools.import_asset_tasks([task])
@@ -136,9 +172,11 @@ class AnimationAlembicLoader(plugin.Loader):
         repre_entity = context["representation"]
         source_path = get_representation_path(repre_entity)
         destination_path = container["namespace"]
-
+        loaded_options = {
+                "abc_conversion_preset": self.abc_conversion_preset
+        }
         task = self.get_task(
-            source_path, destination_path, folder_name, True
+            source_path, destination_path, folder_name, True, loaded_options
         )
 
         # do import fbx and replace existing data

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -6,6 +6,7 @@ from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
 )
+from ayon_core.lib import EnumDef
 from ayon_unreal.api import plugin
 from ayon_unreal.api.pipeline import (
     AYON_ASSET_DIR,
@@ -26,17 +27,51 @@ class PointCacheAlembicLoader(plugin.Loader):
     color = "orange"
 
     root = AYON_ASSET_DIR
+    abc_conversion_preset = "maya"
+
+    @classmethod
+    def apply_settings(cls, project_settings):
+        super(PointCacheAlembicLoader, cls).apply_settings(project_settings)
+        # Apply import settings
+        unreal_settings = project_settings.get("unreal", {})
+        if unreal_settings.get("abc_conversion_preset", cls.abc_conversion_preset):
+            cls.abc_conversion_preset = unreal_settings.get(
+                "abc_conversion_preset", cls.abc_conversion_preset)
+
+    @classmethod
+    def get_options(cls, contexts):
+        return [
+            EnumDef(
+                "abc_conversion_preset",
+                label="Alembic Conversion Preset",
+                items={
+                    "custom": "custom",
+                    "maya": "maya"
+                },
+                default=cls.abc_conversion_preset
+            )
+        ]
 
     @staticmethod
     def get_task(
         filename, asset_dir, asset_name, replace,
-        frame_start=None, frame_end=None
+        frame_start=None, frame_end=None, loaded_options=None
     ):
         task = unreal.AssetImportTask()
         options = unreal.AbcImportSettings()
         gc_settings = unreal.AbcGeometryCacheSettings()
         conversion_settings = unreal.AbcConversionSettings()
         sampling_settings = unreal.AbcSamplingSettings()
+        abc_conversion_preset = loaded_options.get("abc_conversion_preset")
+        if abc_conversion_preset == "maya":
+            conversion_settings = unreal.AbcConversionSettings(
+                preset= unreal.AbcConversionPreset.MAYA)
+        else:
+            conversion_settings = unreal.AbcConversionSettings(
+                preset=unreal.AbcConversionPreset.CUSTOM,
+                flip_u=False, flip_v=True,
+                rotation=[-90.0, 0.0, 180.0],
+                scale=[100.0, 100.0, 100.0])
 
         task.set_editor_property('filename', filename)
         task.set_editor_property('destination_path', asset_dir)
@@ -49,13 +84,6 @@ class PointCacheAlembicLoader(plugin.Loader):
             'import_type', unreal.AlembicImportType.GEOMETRY_CACHE)
 
         gc_settings.set_editor_property('flatten_tracks', False)
-
-        conversion_settings.set_editor_property('flip_u', False)
-        conversion_settings.set_editor_property('flip_v', True)
-        conversion_settings.set_editor_property(
-            'scale', unreal.Vector(x=100.0, y=100.0, z=100.0))
-        conversion_settings.set_editor_property(
-            'rotation', unreal.Vector(x=-90.0, y=0.0, z=180.0))
 
         if frame_start is not None:
             sampling_settings.set_editor_property('frame_start', frame_start)
@@ -71,12 +99,12 @@ class PointCacheAlembicLoader(plugin.Loader):
 
     def import_and_containerize(
         self, filepath, asset_dir, asset_name, container_name,
-        frame_start, frame_end
+        frame_start, frame_end, loaded_options=None
     ):
         unreal.EditorAssetLibrary.make_directory(asset_dir)
 
         task = self.get_task(
-            filepath, asset_dir, asset_name, False, frame_start, frame_end)
+            filepath, asset_dir, asset_name, False, frame_start, frame_end, loaded_options)
 
         unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
 
@@ -159,10 +187,13 @@ class PointCacheAlembicLoader(plugin.Loader):
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             path = self.filepath_from_context(context)
-
+            loaded_options = {
+                "abc_conversion_preset": options.get(
+                    "abc_conversion_preset", self.abc_conversion_preset)
+            }
             self.import_and_containerize(
                 path, asset_dir, asset_name, container_name,
-                frame_start, frame_end)
+                frame_start, frame_end, loaded_options)
 
         self.imprint(
             folder_path,
@@ -214,10 +245,12 @@ class PointCacheAlembicLoader(plugin.Loader):
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             path = get_representation_path(repre_entity)
-
+            loaded_options = {
+                "abc_conversion_preset": self.abc_conversion_preset
+            }
             self.import_and_containerize(
                 path, asset_dir, asset_name, container_name,
-                frame_start, frame_end)
+                frame_start, frame_end, loaded_options)
 
         self.imprint(
             folder_path,

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -26,6 +26,16 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
     color = "orange"
 
     root = AYON_ASSET_DIR
+    abc_conversion_preset = "maya"
+
+    @classmethod
+    def apply_settings(cls, project_settings):
+        super(SkeletalMeshAlembicLoader, cls).apply_settings(project_settings)
+        # Apply import settings
+        unreal_settings = project_settings.get("unreal", {})
+        if unreal_settings.get("abc_conversion_preset", cls.abc_conversion_preset):
+            cls.abc_conversion_preset = unreal_settings.get(
+                "abc_conversion_preset", cls.abc_conversion_preset)
 
     @classmethod
     def get_options(cls, contexts):
@@ -37,7 +47,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
                     "custom": "custom",
                     "maya": "maya"
                 },
-                default="maya"
+                default=cls.abc_conversion_preset
             ),
             EnumDef(
                 "abc_material_settings",
@@ -57,11 +67,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         task = unreal.AssetImportTask()
         options = unreal.AbcImportSettings()
         mat_settings = unreal.AbcMaterialSettings()
-        conversion_settings = unreal.AbcConversionSettings(
-            preset=unreal.AbcConversionPreset.CUSTOM,
-            flip_u=False, flip_v=False,
-            rotation=[0.0, 0.0, 0.0],
-            scale=[1.0, 1.0, 1.0])
+        conversion_settings = unreal.AbcConversionSettings()
 
         task.set_editor_property('filename', filename)
         task.set_editor_property('destination_path', asset_dir)
@@ -172,7 +178,8 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
         loaded_options = {
             "default_conversion": options.get("default_conversion", False),
-            "abc_conversion_preset": options.get("abc_conversion_preset", "maya"),
+            "abc_conversion_preset": options.get(
+                "abc_conversion_preset", self.abc_conversion_preset),
             "abc_material_settings": options.get("abc_material_settings", "no_material")
         }
 
@@ -233,7 +240,10 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             path = get_representation_path(repre_entity)
-            loaded_options = {"default_conversion": False}
+            loaded_options = {
+                "default_conversion": False,
+                "abc_conversion_preset": self.abc_conversion_preset
+            }
             self.import_and_containerize(path, asset_dir, asset_name,
                                          container_name, loaded_options)
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -26,6 +26,17 @@ class StaticMeshAlembicLoader(plugin.Loader):
     color = "orange"
 
     root = AYON_ASSET_DIR
+    abc_conversion_preset = "maya"
+
+
+    @classmethod
+    def apply_settings(cls, project_settings):
+        super(StaticMeshAlembicLoader, cls).apply_settings(project_settings)
+        # Apply import settings
+        unreal_settings = project_settings.get("unreal", {})
+        if unreal_settings.get("abc_conversion_preset", cls.abc_conversion_preset):
+            cls.abc_conversion_preset = unreal_settings.get(
+                "abc_conversion_preset", cls.abc_conversion_preset)
 
     @classmethod
     def get_options(cls, contexts):
@@ -37,7 +48,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
                     "custom": "custom",
                     "maya": "maya"
                 },
-                default="maya"
+                default=cls.abc_conversion_preset
             ),
             EnumDef(
                 "abc_material_settings",
@@ -62,6 +73,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
         options = unreal.AbcImportSettings()
         sm_settings = unreal.AbcStaticMeshSettings()
         mat_settings = unreal.AbcMaterialSettings()
+        conversion_settings = unreal.AbcConversionSettings()
 
         task.set_editor_property('filename', filename)
         task.set_editor_property('destination_path', asset_dir)
@@ -178,7 +190,8 @@ class StaticMeshAlembicLoader(plugin.Loader):
             name_version = f"{name}_v{version:03d}"
         loaded_options = {
             "default_conversion": options.get("default_conversion", False),
-            "abc_conversion_preset": options.get("abc_conversion_preset", "maya"),
+            "abc_conversion_preset": options.get(
+                "abc_conversion_preset", self.abc_conversion_preset),
             "abc_material_settings": options.get("abc_material_settings", "no_material"),
             "merge_meshes": options.get("merge_meshes", True),
         }
@@ -241,7 +254,10 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             path = get_representation_path(repre_entity)
-            loaded_options = {"default_conversion": False}
+            loaded_options = {
+                "default_conversion": False,
+                "abc_conversion_preset": self.abc_conversion_preset
+            }
             self.import_and_containerize(path, asset_dir, asset_name,
                                          container_name, loaded_options)
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -9,6 +9,13 @@ class ProjectSetup(BaseSettingsModel):
     )
 
 
+def _abc_conversion_presets_enum():
+    return [
+        {"value": "maya", "label": "maya"},
+        {"value": "custom", "label": "custom"}
+    ]
+
+
 def _render_format_enum():
     return [
         {"value": "png", "label": "PNG"},
@@ -37,6 +44,13 @@ class UnrealSettings(BaseSettingsModel):
     delete_unmatched_assets: bool = SettingsField(
         False,
         title="Delete assets that are not matched"
+    )
+    abc_conversion_preset: str = SettingsField(
+        "maya",
+        title="Alembic Conversion Setting Presets",
+        enum_resolver=_abc_conversion_presets_enum,
+        description="Presets for converting the loaded alembic "
+                    "with correct UV and transform"
     )
     loaded_assets_extension: str = SettingsField(
         "fbx",
@@ -72,6 +86,7 @@ class UnrealSettings(BaseSettingsModel):
 DEFAULT_VALUES = {
     "level_sequences_for_layouts": True,
     "delete_unmatched_assets": False,
+    "abc_conversion_preset": "maya",
     "loaded_assets_extension": "fbx",
     "render_queue_path": "/Game/Ayon/renderQueue",
     "render_config_path": "/Game/Ayon/DefaultMovieRenderQueueConfig.DefaultMovieRenderQueueConfig",


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/50 by adding new setting for alembic conversion in ayon server.
![image](https://github.com/user-attachments/assets/fc45850f-0edb-4dac-bf55-382ca580910f)

## Additional info
Please build and install unreal addon for this PR

## Testing notes:

1. Install the unreal addon in ayon server after the build
2. Go to `ayon+settings://unreal/abc_conversion_preset` in unreal ayon settings to set your own presets
3. Launch Unreal
4. Load any product type with abc as extension
5. Setting version with the loaded assets in scene inventory