### PR TITLE
Setting Version for animation product loaded assets would have exclusive version folders

### DIFF
--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -422,7 +422,7 @@ class AnimationFBXLoader(plugin.Loader):
             asset_dir,
             container_name,
             asset_name,
-            context["representation"],
+            repre_entity,
             product_type
         )
 

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -344,42 +344,16 @@ class AnimationFBXLoader(plugin.Loader):
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{self.root}/Animations/{folder_name}/{name_version}", suffix=f"_{ext}")
 
-
-        path = self.filepath_from_context(context)
-        libpath = path.replace(".fbx", ".json")
-
-        master_level = None
-
-        # check if json file exists.
-        if os.path.exists(libpath):
-            ar = unreal.AssetRegistryHelpers.get_asset_registry()
-
-            _filter = unreal.ARFilter(
-                class_names=["World"],
-                package_paths=[f"{self.root}/{hierarchy[0]}"],
-                recursive_paths=False)
-            levels = ar.get_assets(_filter)
-            master_level = levels[0].get_asset().get_path_name()
-
-            hierarchy_dir = self.root
-            for h in hierarchy:
-                hierarchy_dir = f"{hierarchy_dir}/{h}"
-            hierarchy_dir = f"{hierarchy_dir}/{folder_name}"
-
-            _filter = unreal.ARFilter(
-                class_names=["World"],
-                package_paths=[f"{hierarchy_dir}/"],
-                recursive_paths=True)
-            levels = ar.get_assets(_filter)
-            level = levels[0].get_asset().get_path_name()
-
-            unreal.EditorLevelLibrary.save_all_dirty_levels()
-            unreal.EditorLevelLibrary.load_level(level)
-
         container_name += suffix
-        # Create Asset Container
-        unreal_pipeline.create_container(
-            container=container_name, path=asset_dir)
+
+        if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
+            master_level = self._import_animation_with_json(
+                path, context, hierarchy,
+                asset_dir, folder_name,
+                asset_name
+            )
+            unreal_pipeline.create_container(
+                container=container_name, path=asset_dir)
 
         self.imprint(
             folder_path,

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -259,9 +259,16 @@ class AnimationFBXLoader(plugin.Loader):
 
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
+        version = context["version"]["version"]
+        # Check if version is hero version and use different name
+        if version < 0:
+            name_version = f"{name}_hero"
+        else:
+            name_version = f"{name}_v{version:03d}"
+
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/Animations/{folder_name}/{name}", suffix="")
+            f"{root}/Animations/{folder_name}/{name_version}", suffix="")
 
         path = self.filepath_from_context(context)
         libpath = path.replace(".fbx", ".json")


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/51

## Additional info
n/a
Should be merged after: https://github.com/ynput/ayon-unreal/pull/54

## Testing notes:

1. Launch Unreal
2. Load Animation product with fbx animation loader
3. Setting version
4. Should have separate version folders/not overwrite the product version as if other imported assets from other loaders
