### PR TITLE
make sure the hierarchy_dir is correct when generating sequence

### DIFF
--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -621,6 +621,10 @@ def generate_sequence(h, h_dir):
         min_frame = folder_entity["attrib"]["clipIn"]
         max_frame = folder_entity["attrib"]["clipOut"]
         fps = folder_entity["attrib"]["fps"]
+    else:
+        unreal.log_warning(
+            "Folder Entity not found. Using default Unreal frame range value."
+        )
 
     sequence.set_display_rate(
         unreal.FrameRate(fps, 1.0))

--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import re
 import json
 import clique
 import logging
@@ -601,12 +602,17 @@ def generate_sequence(h, h_dir):
     )
 
     project_name = get_current_project_name()
-    # TODO Fix this does not return folder path
-    folder_path = h_dir.split('/')[-1]
+    filtered_dir = "/Game/Ayon/"
+    folder_path = re.sub(filtered_dir, "", h_dir)
     folder_entity = ayon_api.get_folder_by_path(
         project_name,
         folder_path,
-        fields={"id", "attrib.fps"}
+        fields={
+            "id",
+            "attrib.fps",
+            "attrib.clipIn",
+            "attrib.clipOut"
+        }
     )
     start_frames = []
     end_frames = []
@@ -620,6 +626,7 @@ def generate_sequence(h, h_dir):
             parent_ids=[folder_entity["id"]],
             fields={"id", "attrib.clipIn", "attrib.clipOut"}
         ))
+
         for e in elements:
             start_frames.append(e["attrib"].get("clipIn"))
             end_frames.append(e["attrib"].get("clipOut"))

--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import re
 import json
 import clique
 import logging

--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -603,7 +603,7 @@ def generate_sequence(h, h_dir):
 
     project_name = get_current_project_name()
     filtered_dir = "/Game/Ayon/"
-    folder_path = re.sub(filtered_dir, "", h_dir)
+    folder_path = h_dir.replace(filtered_dir, "")
     folder_entity = ayon_api.get_folder_by_path(
         project_name,
         folder_path,
@@ -614,33 +614,14 @@ def generate_sequence(h, h_dir):
             "attrib.clipOut"
         }
     )
-    start_frames = []
-    end_frames = []
-    # unreal default fps value
+    # unreal default frame range value
     fps = 60.0
+    min_frame = sequence.get_playback_start()
+    max_frame = sequence.get_playback_end()
     if folder_entity:
-        unreal.log("Found folder entity data: {}".format(folder_entity))
-
-        elements = list(ayon_api.get_folders(
-            project_name,
-            parent_ids=[folder_entity["id"]],
-            fields={"id", "attrib.clipIn", "attrib.clipOut"}
-        ))
-
-        for e in elements:
-            start_frames.append(e["attrib"].get("clipIn"))
-            end_frames.append(e["attrib"].get("clipOut"))
-
-            elements.extend(ayon_api.get_folders(
-                project_name,
-                parent_ids=[e["id"]],
-                fields={"id", "attrib.clipIn", "attrib.clipOut"}
-            ))
-
-        fps = folder_entity["attrib"].get("fps")
-    min_frame = min(start_frames, default=sequence.get_playback_start())
-    max_frame = max(end_frames, default=sequence.get_playback_end())
-
+        min_frame = folder_entity["attrib"]["clipIn"]
+        max_frame = folder_entity["attrib"]["clipOut"]
+        fps = folder_entity["attrib"]["fps"]
 
     sequence.set_display_rate(
         unreal.FrameRate(fps, 1.0))


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/59

Level Sequence should set the frame ranges accordingly to the clipIn & clipOut value set in the folder hierarchies in the project editor(See the screenshot below)
![image](https://github.com/user-attachments/assets/ad101242-e527-4017-9634-dd143d3eda06)

![image](https://github.com/user-attachments/assets/724ac1b8-ba4d-4fc0-9291-31ddca0f86ee)


## Additional info
Also tested with camera loader and layout loader
The hardcoded naming should be resolved in the template setting PR: https://github.com/ynput/ayon-unreal/pull/57

## Testing notes:

1. Launch Unreal
2. Ayon -> Generate Sequence Hierarchy
3. Click in the level sequence form where you click to generate the sequence hierarchy
4. The Clip In and Clip Out value should be set accordingly to how we set in the project editor