### PR TITLE
Add animation/pointcache families support in replacing actors actions

### DIFF
--- a/client/ayon_unreal/plugins/inventory/update_actors.py
+++ b/client/ayon_unreal/plugins/inventory/update_actors.py
@@ -10,7 +10,7 @@ from ayon_core.pipeline import InventoryAction
 
 
 def update_assets(containers, selected):
-    allowed_families = ["model", "rig"]
+    allowed_families = ["animation", "model", "rig", "pointcache"]
 
     # Get all the containers in the Unreal Project
     all_containers = ls()
@@ -49,12 +49,26 @@ def update_assets(containers, selected):
                     old_content, asset_content, selected)
                 replace_static_mesh_actors(
                     old_content, asset_content, selected)
+
             elif container.get("family") == "model":
                 if container.get("loader") == "PointCacheAlembicLoader":
                     replace_geometry_cache_actors(
                         old_content, asset_content, selected)
                 else:
                     replace_static_mesh_actors(
+                        old_content, asset_content, selected)
+
+            elif container.get("family") == "pointcache":
+                if container.get("loader") == "PointCacheAlembicLoader":
+                    replace_geometry_cache_actors(
+                        old_content, asset_content, selected)
+                else:
+                    replace_skeletal_mesh_actors(
+                        old_content, asset_content, selected)
+
+            elif container.get("family") == "animation":
+                if container.get("loader") == "AnimationAlembicLoader":
+                    replace_skeletal_mesh_actors(
                         old_content, asset_content, selected)
 
             unreal.EditorLevelLibrary.save_current_level()


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/61
This PR is to add pointcache/animation support of replacing all/selected actors as inventory actions.


## Additional info
It does not support for the loaded asset from fbx animation loaders if users want to replace actors in animation families.


## Testing notes:

1. Launch Unreal
2. Load pointcache/animation/rig/model assets
3. Load some assets
4. Go to Ayon -> Manage
5. Use inventory action below 
![image](https://github.com/user-attachments/assets/5f8989b8-f45d-419e-b77e-abd6751a8139)

