### PR TITLE
Make sure instance members are always list value for publishing uasset/Uasset loader can load the uasset

### DIFF
--- a/client/ayon_unreal/api/plugin.py
+++ b/client/ayon_unreal/api/plugin.py
@@ -81,6 +81,8 @@ class UnrealCreateLogic():
                 instance.get('creator_attributes', '{}'))
             instance['publish_attributes'] = ast.literal_eval(
                 instance.get('publish_attributes', '{}'))
+            instance['members'] = ast.literal_eval(
+                instance.get('members', '[]'))
             created_instance = CreatedInstance.from_existing(instance, self)
             self._add_instance_to_context(created_instance)
 

--- a/client/ayon_unreal/api/plugin.py
+++ b/client/ayon_unreal/api/plugin.py
@@ -83,6 +83,10 @@ class UnrealCreateLogic():
                 instance.get('publish_attributes', '{}'))
             instance['members'] = ast.literal_eval(
                 instance.get('members', '[]'))
+            instance['families'] = ast.literal_eval(
+                instance.get('families', '[]'))
+            instance['active'] = ast.literal_eval(
+                instance.get('active', ''))
             created_instance = CreatedInstance.from_existing(instance, self)
             self._add_instance_to_context(created_instance)
 

--- a/client/ayon_unreal/plugins/load/load_uasset.py
+++ b/client/ayon_unreal/plugins/load/load_uasset.py
@@ -67,19 +67,11 @@ class UAssetLoader(plugin.Loader):
             "/Game", Path(unreal.Paths.project_content_dir()).as_posix(), 1)
 
         path = self.filepath_from_context(context)
-        asset_name = os.path.basename(path)
+        new_asset = os.path.basename(path)
+        new_asset_name = os.path.splitext(new_asset)[-1].lstrip(".")
         shutil.copy(
             path,
-            f"{destination_path}/{asset_name}")
-
-        asset = unreal.EditorAssetLibrary.load_asset(f"{asset_dir}/{asset_name}")
-        #rename the incoming assets to align with the container name
-        rename_data = unreal.AssetRenameData(
-            asset=asset, new_package_path=asset_dir,
-            new_name=f"{name}_{unique_number:02}"
-        )
-        # Perform the rename operation
-        unreal.AssetToolsHelpers.get_asset_tools().rename_assets([rename_data])
+            f"{destination_path}/{new_asset}")
 
         # Create Asset Container
         unreal_pipeline.create_container(
@@ -92,7 +84,7 @@ class UAssetLoader(plugin.Loader):
             "namespace": asset_dir,
             "folder_path": folder_path,
             "container_name": container_name,
-            "asset_name": asset_name,
+            "asset_name": new_asset_name,
             "loader": str(self.__class__.__name__),
             "representation": context["representation"]["id"],
             "parent": context["representation"]["versionId"],
@@ -117,10 +109,7 @@ class UAssetLoader(plugin.Loader):
 
         asset_dir = container["namespace"]
 
-        product_name = context["product"]["name"]
         repre_entity = context["representation"]
-
-        unique_number = container["container_name"].split("_")[-2]
 
         destination_path = asset_dir.replace(
             "/Game", Path(unreal.Paths.project_content_dir()).as_posix(), 1)
@@ -135,17 +124,8 @@ class UAssetLoader(plugin.Loader):
                 unreal.EditorAssetLibrary.delete_asset(asset)
 
         update_filepath = get_representation_path(repre_entity)
-        asset_name = os.path.basename(update_filepath)
-        shutil.copy(update_filepath, f"{destination_path}/{asset_name}")
-
-        asset = unreal.EditorAssetLibrary.load_asset(f"{asset_dir}/{asset_name}")
-        #rename the incoming assets to align with the container name
-        rename_data = unreal.AssetRenameData(
-            asset=asset, new_package_path=asset_dir,
-            new_name=f"{product_name}_{unique_number}"
-        )
-        # Perform the rename operation
-        unreal.AssetToolsHelpers.get_asset_tools().rename_assets([rename_data])
+        new_asset_name = os.path.basename(update_filepath)
+        shutil.copy(update_filepath, f"{destination_path}/{new_asset_name}")
 
         container_path = f'{container["namespace"]}/{container["objectName"]}'
         # update metadata

--- a/client/ayon_unreal/plugins/load/load_uasset.py
+++ b/client/ayon_unreal/plugins/load/load_uasset.py
@@ -66,8 +66,7 @@ class UAssetLoader(plugin.Loader):
             "/Game", Path(unreal.Paths.project_content_dir()).as_posix(), 1)
 
         path = self.filepath_from_context(context)
-        asset = os.path.basename(path)
-        asset_name = os.path.splitext(asset)[-1].lstrip(".")
+        asset_name = os.path.basename(path)
         shutil.copy(
             path,
             f"{destination_path}/{asset_name}")

--- a/client/ayon_unreal/plugins/load/load_uasset.py
+++ b/client/ayon_unreal/plugins/load/load_uasset.py
@@ -46,7 +46,6 @@ class UAssetLoader(plugin.Loader):
         folder_path = context["folder"]["path"]
         folder_name = context["folder"]["name"]
         suffix = "_CON"
-        asset_name = f"{folder_name}_{name}" if folder_name else f"{name}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             f"{root}/{folder_name}/{name}", suffix=""

--- a/client/ayon_unreal/plugins/load/load_uasset.py
+++ b/client/ayon_unreal/plugins/load/load_uasset.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Load UAsset."""
 from pathlib import Path
+import os
 import shutil
 
 from ayon_core.pipeline import (
@@ -66,9 +67,19 @@ class UAssetLoader(plugin.Loader):
             "/Game", Path(unreal.Paths.project_content_dir()).as_posix(), 1)
 
         path = self.filepath_from_context(context)
+        asset_name = os.path.basename(path)
         shutil.copy(
             path,
-            f"{destination_path}/{name}_{unique_number:02}.{self.extension}")
+            f"{destination_path}/{asset_name}")
+
+        asset = unreal.EditorAssetLibrary.load_asset(f"{asset_dir}/{asset_name}")
+        #rename the incoming assets to align with the container name
+        rename_data = unreal.AssetRenameData(
+            asset=asset, new_package_path=asset_dir,
+            new_name=f"{name}_{unique_number:02}"
+        )
+        # Perform the rename operation
+        unreal.AssetToolsHelpers.get_asset_tools().rename_assets([rename_data])
 
         # Create Asset Container
         unreal_pipeline.create_container(
@@ -124,11 +135,17 @@ class UAssetLoader(plugin.Loader):
                 unreal.EditorAssetLibrary.delete_asset(asset)
 
         update_filepath = get_representation_path(repre_entity)
+        asset_name = os.path.basename(update_filepath)
+        shutil.copy(update_filepath, f"{destination_path}/{asset_name}")
 
-        shutil.copy(
-            update_filepath,
-            f"{destination_path}/{product_name}_{unique_number}.{self.extension}"
+        asset = unreal.EditorAssetLibrary.load_asset(f"{asset_dir}/{asset_name}")
+        #rename the incoming assets to align with the container name
+        rename_data = unreal.AssetRenameData(
+            asset=asset, new_package_path=asset_dir,
+            new_name=f"{product_name}_{unique_number}"
         )
+        # Perform the rename operation
+        unreal.AssetToolsHelpers.get_asset_tools().rename_assets([rename_data])
 
         container_path = f'{container["namespace"]}/{container["objectName"]}'
         # update metadata

--- a/client/ayon_unreal/plugins/load/load_uasset.py
+++ b/client/ayon_unreal/plugins/load/load_uasset.py
@@ -66,11 +66,11 @@ class UAssetLoader(plugin.Loader):
             "/Game", Path(unreal.Paths.project_content_dir()).as_posix(), 1)
 
         path = self.filepath_from_context(context)
-        new_asset = os.path.basename(path)
-        new_asset_name = os.path.splitext(new_asset)[-1].lstrip(".")
+        asset = os.path.basename(path)
+        asset_name = os.path.splitext(asset)[-1].lstrip(".")
         shutil.copy(
             path,
-            f"{destination_path}/{new_asset}")
+            f"{destination_path}/{asset_name}")
 
         # Create Asset Container
         unreal_pipeline.create_container(
@@ -83,7 +83,7 @@ class UAssetLoader(plugin.Loader):
             "namespace": asset_dir,
             "folder_path": folder_path,
             "container_name": container_name,
-            "asset_name": new_asset_name,
+            "asset_name": asset_name,
             "loader": str(self.__class__.__name__),
             "representation": context["representation"]["id"],
             "parent": context["representation"]["versionId"],


### PR DESCRIPTION
## Changelog Description
Make sure the instance members are always list value
Related issue: https://github.com/ynput/ayon-unreal/issues/65, https://github.com/ynput/ayon-unreal/issues/64, https://github.com/ynput/ayon-unreal/issues/63


## Additional info
Please the PR along with this ticket https://github.com/ynput/ayon-core/pull/859
And with this setting below or with the backend ticket https://github.com/ynput/ayon-backend/pull/328.
![image](https://github.com/user-attachments/assets/c6e1fa7c-778e-4b7c-80f8-9a64459be174)

```
name: unrealuasset
directory: {root[work]}/{project[name]}/{hierarchy}/{folder[name]}/publish/{product[type]}/{product[name]}/{@version}
filename: {originalBasename}.{ext}
```

<strike>***There are some limitations for loading the uasset/umap btw. You need to perform "delete" the files manually to make it visible. (which is strange)</strike> (https://github.com/ynput/ayon-unreal/pull/69/commits/6039c80548f90c0909358bc056c21386b5b0b611)

<strike>https://github.com/user-attachments/assets/739cf10e-e119-470b-81c3-43d7504114eb</strike>

Demonstration:

https://github.com/user-attachments/assets/644e9ffa-8137-4f92-a356-16b135c3c96c



## Testing notes:

1. Create UAsset/Umap/Camera Instance
2. Close the publisher
3. Open the publisher again
4. Publish
5. Should be published successfully without error.
