### PR TITLE
Add missing extractor for staticmesh product type

### DIFF
--- a/client/ayon_unreal/api/plugin.py
+++ b/client/ayon_unreal/api/plugin.py
@@ -81,6 +81,12 @@ class UnrealCreateLogic():
                 instance.get('creator_attributes', '{}'))
             instance['publish_attributes'] = ast.literal_eval(
                 instance.get('publish_attributes', '{}'))
+            instance['members'] = ast.literal_eval(
+                instance.get('members', '[]'))
+            instance['families'] = ast.literal_eval(
+                instance.get('families', '[]'))
+            instance['active'] = ast.literal_eval(
+                instance.get('active', ''))
             created_instance = CreatedInstance.from_existing(instance, self)
             self._add_instance_to_context(created_instance)
 

--- a/client/ayon_unreal/plugins/create/create_staticmeshfbx.py
+++ b/client/ayon_unreal/plugins/create/create_staticmeshfbx.py
@@ -9,5 +9,5 @@ class CreateStaticMeshFBX(UnrealAssetCreator):
 
     identifier = "io.ayon.creators.unreal.staticmeshfbx"
     label = "Static Mesh (FBX)"
-    product_type = "unrealStaticMesh"
+    product_type = "staticMesh"
     icon = "cube"

--- a/client/ayon_unreal/plugins/publish/collect_instance_members.py
+++ b/client/ayon_unreal/plugins/publish/collect_instance_members.py
@@ -14,7 +14,7 @@ class CollectInstanceMembers(pyblish.api.InstancePlugin):
 
     order = pyblish.api.CollectorOrder + 0.1
     hosts = ["unreal"]
-    families = ["camera", "look", "unrealStaticMesh", "uasset"]
+    families = ["camera", "look", "staticMesh", "uasset"]
     label = "Collect Instance Members"
 
     def process(self, instance):

--- a/client/ayon_unreal/plugins/publish/extract_fbx.py
+++ b/client/ayon_unreal/plugins/publish/extract_fbx.py
@@ -7,7 +7,7 @@ from ayon_core.pipeline import publish
 class ExtractFbx(publish.Extractor):
     """Extract Fbx."""
 
-    label = "Extract Fbx"
+    label = "Extract Fbx (Static Mesh)"
     hosts = ["unreal"]
     families = ["staticMesh"]
 
@@ -22,23 +22,20 @@ class ExtractFbx(publish.Extractor):
         options.set_editor_property('collision', False)
         fbx_filename = f"{instance.name}.fbx"
 
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
-
         task = unreal.AssetExportTask()
         task.exporter = fbx_exporter
         task.options = options
+        members = set(instance.data.get("members", []))
+        asset_registry = unreal.AssetRegistryHelpers.get_asset_registry()
+        for member in members:
+            task.object = asset_registry.get_asset_by_object_path(member).get_asset()
+            task.automated = True
+            task.filename = os.path.join(staging_dir, fbx_filename).replace("\\", "/")
+            task.selected = False
+            task.use_file_archive = False
+            task.write_empty_files = False
 
-        for member in instance.data.get("members"):
-            target_asset = ar.get_asset_by_object_path(member).get_asset()
-            task.object = target_asset
-        task.automated = True
-        task.filename = os.path.join(staging_dir, fbx_filename).replace("\\", "/")
-        task.prompt = True
-        task.selected = True
-        task.use_file_archive = False
-        task.write_empty_files = True
-
-        unreal.Exporter.run_asset_export_task(task)
+            unreal.Exporter.run_asset_export_task(task)
 
         if "representations" not in instance.data:
             instance.data["representations"] = []

--- a/client/ayon_unreal/plugins/publish/extract_fbx.py
+++ b/client/ayon_unreal/plugins/publish/extract_fbx.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
-
 import unreal
 
 from ayon_core.pipeline import publish

--- a/client/ayon_unreal/plugins/publish/extract_fbx.py
+++ b/client/ayon_unreal/plugins/publish/extract_fbx.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import unreal
-
+import os
 from ayon_core.pipeline import publish
 
 
@@ -25,19 +25,18 @@ class ExtractFbx(publish.Extractor):
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
 
         task = unreal.AssetExportTask()
-        task.set_editor_property('exporter', fbx_exporter)
-        task.set_editor_property('options', options)
+        task.exporter = fbx_exporter
+        task.options = options
 
         for member in instance.data.get("members"):
             target_asset = ar.get_asset_by_object_path(member).get_asset()
-            asset_names = target_asset.get_name()
-            task.set_editor_property('automated', True)
-            task.set_editor_property('object', asset_names)
-
-        task.set_editor_property(
-            'filename', f"{staging_dir}/{fbx_filename}")
-        task.set_editor_property('prompt', False)
-        task.set_editor_property('selected', False)
+            task.object = target_asset
+        task.automated = True
+        task.filename = os.path.join(staging_dir, fbx_filename).replace("\\", "/")
+        task.prompt = True
+        task.selected = True
+        task.use_file_archive = False
+        task.write_empty_files = True
 
         unreal.Exporter.run_asset_export_task(task)
 
@@ -52,3 +51,4 @@ class ExtractFbx(publish.Extractor):
         }
 
         instance.data["representations"].append(representation)
+        self.log.debug(f"{staging_dir}/{fbx_filename}")

--- a/client/ayon_unreal/plugins/publish/extract_fbx.py
+++ b/client/ayon_unreal/plugins/publish/extract_fbx.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import os
+
+import unreal
+
+from ayon_core.pipeline import publish
+
+
+class ExtractFbx(publish.Extractor):
+    """Extract Fbx."""
+
+    label = "Extract Fbx"
+    hosts = ["unreal"]
+    families = ["staticMesh"]
+
+    def process(self, instance):
+        staging_dir = self.staging_dir(instance)
+        # TODO: select the asset during context
+        fbx_exporter = unreal.StaticMeshExporterFBX()
+        fbx_exporter.set_editor_property('text', False)
+
+        options = unreal.FbxExportOption()
+        options.set_editor_property('ascii', False)
+        options.set_editor_property('collision', False)
+        fbx_filename = f"{instance.name}.fbx"
+
+        ar = unreal.AssetRegistryHelpers.get_asset_registry()
+
+        task = unreal.AssetExportTask()
+        task.set_editor_property('exporter', fbx_exporter)
+        task.set_editor_property('options', options)
+
+        for member in instance.data.get("members"):
+            target_asset = ar.get_asset_by_object_path(member).get_asset()
+            asset_names = target_asset.get_name()
+            task.set_editor_property('automated', True)
+            task.set_editor_property('object', asset_names)
+
+        task.set_editor_property(
+            'filename', f"{staging_dir}/{fbx_filename}")
+        task.set_editor_property('prompt', False)
+        task.set_editor_property('selected', False)
+
+        unreal.Exporter.run_asset_export_task(task)
+
+        if "representations" not in instance.data:
+            instance.data["representations"] = []
+
+        representation = {
+            'name': 'fbx',
+            'ext': 'fbx',
+            'files': fbx_filename,
+            "stagingDir": staging_dir,
+        }
+
+        instance.data["representations"].append(representation)

--- a/client/ayon_unreal/plugins/publish/validate_model_content.py
+++ b/client/ayon_unreal/plugins/publish/validate_model_content.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import unreal
+import pyblish.api
+from ayon_core.pipeline.publish import PublishValidationError
+
+
+class ValidateNoDependencies(pyblish.api.InstancePlugin):
+    """Ensure the model contents are staticMesh
+    """
+
+    order = pyblish.api.ValidatorOrder
+    label = "Validate Model Content"
+    families = ["staticMesh"]
+    hosts = ["unreal"]
+
+    def process(self, instance):
+        invalid_asset = []
+        members = set(instance.data.get("members", []))
+        asset_registry = unreal.AssetRegistryHelpers.get_asset_registry()
+        for member in members:
+            asset = asset_registry.get_asset_by_object_path(member).get_asset()
+            if asset.get_class().get_name() != "StaticMesh":
+                invalid_asset.append(member)
+
+        if invalid_asset:
+            raise PublishValidationError(
+                f"{invalid_asset} are not static Mesh.", title="Incorrect Model Type")


### PR DESCRIPTION
## Changelog Description
This PR is to add missing fbx extractor for staticMesh product type and also use `staticMesh` as product type instead of `unrealStaticMesh` to align with the unreal workflow to other dccs


## Additional info
We need to discuss the use case of this product type in Unreal to other DCCs

## Testing notes:

1. Select Asset and create staticmesh instance
2. Publish
