### PR TITLE
Make sure the animation asset should be at the Animations folder

### DIFF
--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -161,14 +161,15 @@ class AnimationAlembicLoader(plugin.Loader):
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
+            f"{self.root}/Animations/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             unreal.EditorAssetLibrary.make_directory(asset_dir)
             loaded_options = {
-                "abc_conversion_preset": options.get("abc_conversion_preset", self.abc_conversion_preset),
+                "abc_conversion_preset": options.get(
+                    "abc_conversion_preset", self.abc_conversion_preset),
                 "frameStart": folder_entity["attrib"]["frameStart"],
                 "frameEnd": folder_entity["attrib"]["frameEnd"]
             }
@@ -236,7 +237,7 @@ class AnimationAlembicLoader(plugin.Loader):
         # do import fbx and replace existing data
         asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
         asset_dir, container_name = asset_tools.create_unique_asset_name(
-            f"{self.root}/{folder_name}/{name_version}", suffix=f"_{ext}")
+            f"{self.root}/Animations/{folder_name}/{name_version}", suffix=f"_{ext}")
 
         container_name += suffix
 


### PR DESCRIPTION
## Changelog Description
Make sure the animation asset (both fbx and abc) should be at the Animations folder
Resolve https://github.com/ynput/ayon-unreal/issues/76

## Additional info
n/a


## Testing notes:

1. Load Animation (both fbx and abc)
2. Should be at Animations folder
