### PR TITLE
Camera Loader can set version and delete version

### DIFF
--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -109,7 +109,7 @@ class CameraLoader(plugin.Loader):
         tools = unreal.AssetToolsHelpers().get_asset_tools()
 
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{hierarchy_dir}/{folder_name}/{name_version}", suffix="")
+            f"{hierarchy_dir}/{folder_name}/{name}", suffix="")
 
         container_name += suffix
 
@@ -124,11 +124,11 @@ class CameraLoader(plugin.Loader):
             EditorLevelLibrary.new_level(f"{h_dir}/{h_asset}_map")
 
         level = (
-            f"{asset_dir}/{folder_name}_{name_version}_map_camera.{folder_name}_{name_version}_map_camera"
+            f"{asset_dir}/{folder_name}_{name}_map_camera.{folder_name}_{name}_map_camera"
         )
         if not EditorAssetLibrary.does_asset_exist(level):
             EditorLevelLibrary.new_level(
-                f"{asset_dir}/{folder_name}_{name_version}_map_camera"
+                f"{asset_dir}/{folder_name}_{name}_map_camera"
             )
 
             EditorLevelLibrary.load_level(master_level)
@@ -170,7 +170,7 @@ class CameraLoader(plugin.Loader):
         EditorAssetLibrary.make_directory(asset_dir)
 
         cam_seq = tools.create_asset(
-            asset_name=f"{folder_name}_{name_version}_camera",
+            asset_name=f"{folder_name}_{name}_camera",
             package_path=asset_dir,
             asset_class=unreal.LevelSequence,
             factory=unreal.LevelSequenceFactoryNew()
@@ -297,7 +297,7 @@ class CameraLoader(plugin.Loader):
         playback_start = level_sequence.get_playback_start()
         playback_end = level_sequence.get_playback_end()
 
-        sequence_name = f"{container.get('asset')}_camera"
+        sequence_name = f"{container.get('asset_name')}_camera"
 
         # Get the actors in the level sequence.
         objs = unreal.SequencerTools.get_bound_objects(
@@ -325,12 +325,14 @@ class CameraLoader(plugin.Loader):
         root = "/Game/Ayon"
         namespace = container.get('namespace').replace(f"{root}/", "")
         ms_asset = namespace.split('/')[0]
-        _filter = unreal.ARFilter(
-            class_names=["World"],
-            package_paths=[f"{root}/{ms_asset}"],
-            recursive_paths=False)
-        levels = ar.get_assets(_filter)
-        master_level = levels[0].get_path_name()        # AssetData
+        # _filter = unreal.ARFilter(
+        #     class_names=["World"],
+        #     package_paths=[f"{root}/{ms_asset}"],
+        #     recursive_paths=False)
+        # levels = ar.get_assets(_filter)
+        # master_level = unreal.AssetRegistryHelpers.get_asset(levels[0]).get_path_name()
+        # self.log.debug("master level")
+        # self.log.debug(master_level)
 
         EditorAssetLibrary.delete_asset(level_sequence.get_path_name())
 
@@ -401,7 +403,7 @@ class CameraLoader(plugin.Loader):
         for a in asset_content:
             EditorAssetLibrary.save_asset(a)
 
-        EditorLevelLibrary.load_level(master_level)
+        # EditorLevelLibrary.load_level(master_level)
 
         if curr_level_sequence:
             LevelSequenceLib.open_level_sequence(curr_level_sequence)

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -100,12 +100,6 @@ class CameraLoader(plugin.Loader):
             hierarchy_dir_list.append(hierarchy_dir)
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else name
-        version = context["version"]["version"]
-        # Check if version is hero version and use different name
-        if version < 0:
-            name_version = f"{name}_hero"
-        else:
-            name_version = f"{name}_v{version:03d}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
 
         asset_dir, container_name = tools.create_unique_asset_name(
@@ -325,14 +319,6 @@ class CameraLoader(plugin.Loader):
         root = "/Game/Ayon"
         namespace = container.get('namespace').replace(f"{root}/", "")
         ms_asset = namespace.split('/')[0]
-        # _filter = unreal.ARFilter(
-        #     class_names=["World"],
-        #     package_paths=[f"{root}/{ms_asset}"],
-        #     recursive_paths=False)
-        # levels = ar.get_assets(_filter)
-        # master_level = unreal.AssetRegistryHelpers.get_asset(levels[0]).get_path_name()
-        # self.log.debug("master level")
-        # self.log.debug(master_level)
 
         EditorAssetLibrary.delete_asset(level_sequence.get_path_name())
 

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -31,6 +31,7 @@ class CameraLoader(plugin.Loader):
     representations = {"fbx"}
     icon = "cube"
     color = "orange"
+    root = "/Game/Ayon"
 
     def _import_camera(
         self, world, sequence, bindings, import_fbx_settings, import_filename
@@ -92,8 +93,7 @@ class CameraLoader(plugin.Loader):
         # Pop folder name
         folder_name = hierarchy_parts.pop(-1)
 
-        root = "/Game/Ayon"
-        hierarchy_dir = root
+        hierarchy_dir = self.root
         hierarchy_dir_list = []
         for h in hierarchy_parts:
             hierarchy_dir = f"{hierarchy_dir}/{h}"
@@ -316,8 +316,7 @@ class CameraLoader(plugin.Loader):
         # Remove the Level Sequence from the parent.
         # We need to traverse the hierarchy from the master sequence to find
         # the level sequence.
-        root = "/Game/Ayon"
-        namespace = container.get('namespace').replace(f"{root}/", "")
+        namespace = container.get('namespace').replace(f"{self.root}/", "")
         ms_asset = namespace.split('/')[0]
 
         EditorAssetLibrary.delete_asset(level_sequence.get_path_name())
@@ -384,7 +383,7 @@ class CameraLoader(plugin.Loader):
         EditorLevelLibrary.save_current_level()
 
         asset_content = EditorAssetLibrary.list_assets(
-            f"{root}/{ms_asset}", recursive=True, include_folder=False)
+            f"{self.root}/{ms_asset}", recursive=True, include_folder=False)
 
         for a in asset_content:
             EditorAssetLibrary.save_asset(a)
@@ -399,12 +398,11 @@ class CameraLoader(plugin.Loader):
         editor_subsystem.set_level_viewport_camera_info(vp_loc, vp_rot)
 
     def remove(self, container):
-        root = "/Game/Ayon"
         asset_dir = container.get('namespace')
         # Create a temporary level to delete the layout level.
         EditorLevelLibrary.save_all_dirty_levels()
-        EditorAssetLibrary.make_directory(f"{root}/tmp")
-        tmp_level = f"{root}/tmp/temp_map"
+        EditorAssetLibrary.make_directory(f"{self.root}/tmp")
+        tmp_level = f"{self.root}/tmp/temp_map"
         if not EditorAssetLibrary.does_asset_exist(f"{tmp_level}.temp_map"):
             EditorLevelLibrary.new_level(tmp_level)
         else:
@@ -416,4 +414,4 @@ class CameraLoader(plugin.Loader):
         # Load the default level
         default_level_path = "/Engine/Maps/Templates/OpenWorld"
         EditorLevelLibrary.load_level(default_level_path)
-        EditorAssetLibrary.delete_directory(f"{root}/tmp")
+        EditorAssetLibrary.delete_directory(f"{self.root}/tmp")


### PR DESCRIPTION
## Changelog Description
This PR is to fix the error encountered during setting version and deleting items with the loaded camera assets.
Resolve https://github.com/ynput/ayon-unreal/issues/81
- [x] set version
- [x] delete version

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->


## Testing notes:

1. Load Camera
2. Set Version 
3. Delete Version
