### PR TITLE
Supports switch version for camera loader

### DIFF
--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -397,6 +397,9 @@ class CameraLoader(plugin.Loader):
 
         editor_subsystem.set_level_viewport_camera_info(vp_loc, vp_rot)
 
+    def switch(self, container, context):
+        self.update(container, context)
+
     def remove(self, container):
         asset_dir = container.get('namespace')
         # Create a temporary level to delete the layout level.


### PR DESCRIPTION
## Changelog Description
This PR is to add switch version support for camera loader
Resolve #87 


## Additional info
n/a


## Testing notes:

1. Load Camera
2. Go to Ayon -> Manage
3. Right Click the camera instance-> Switch Folder
4. Should be working