### PR TITLE
Temp map should be removed after removing layout product type

### DIFF
--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -960,4 +960,7 @@ class LayoutLoader(plugin.Loader):
 
         if create_sequences:
             EditorLevelLibrary.load_level(master_level)
+            # Load the default level
+            default_level_path = "/Engine/Maps/Templates/OpenWorld"
+            EditorLevelLibrary.load_level(default_level_path)
             EditorAssetLibrary.delete_directory(f"{root}/tmp")


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/93
This PR is to ensure temp map has been removed and the default level should be loaded after removing the asset from layout product type.


## Additional info
n/a


## Testing notes:

1. Load Layout
2. Delete Layout with scene inventory
3. Default Level Path should be loaded.
