### PR TITLE
Make deletion of the loaded assets as optional when removing layout product type

### DIFF
--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -876,7 +876,7 @@ class LayoutLoader(plugin.Loader):
         if remove_loaded_assets:
             remove_asset_confirmation_dialog = unreal.EditorDialog.show_message(
                 "The removal of the loaded assets",
-                "All the loaded assets from this layout have been removed. Would you like to continue?",
+                "The layout will be removed. Do you want to delete all associated assets as well?",
                 unreal.AppMsgType.YES_NO)
             if (remove_asset_confirmation_dialog == unreal.AppReturnType.YES):
                 _remove_loaded_asset(container)

--- a/server/settings.py
+++ b/server/settings.py
@@ -51,6 +51,10 @@ class UnrealSettings(BaseSettingsModel):
         False,
         title="Generate level sequences when loading layouts"
     )
+    remove_loaded_assets: bool = SettingsField(
+        False,
+        title="Remove loaded assets when deleting layouts"
+    )
     delete_unmatched_assets: bool = SettingsField(
         False,
         title="Delete assets that are not matched"
@@ -95,6 +99,7 @@ class UnrealSettings(BaseSettingsModel):
 
 DEFAULT_VALUES = {
     "level_sequences_for_layouts": True,
+    "remove_loaded_assets": False,
     "delete_unmatched_assets": False,
     "abc_conversion_preset": "maya",
     "loaded_assets_extension": "fbx",


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/97
This PR is to introduce the optional setting for deleting the loaded assets when removing layouts.

## Additional info
n/a

## Testing notes:

1. Build addon with this branch
2. Install addon
3. Go to `ayon+settings://unreal/remove_loaded_assets` to turn on/off the toggle
4. Load Layout
5. Ayon -> Manage
6. Perform `Remove items` upon the layout with the inventory tool
