### PR TITLE
Checking skeletal mesh component when connecting alembic animation to level sequence performed

### DIFF
--- a/client/ayon_unreal/api/lib.py
+++ b/client/ayon_unreal/api/lib.py
@@ -37,8 +37,11 @@ def update_skeletal_mesh(asset_content, sequence):
                     skeletal_mesh = skeletal_mesh_component.skeletal_mesh
                     if skeletal_mesh:
                         skel_mesh_comp = actor.get_editor_property('skeletal_mesh_component')
-                        if skel_mesh_comp.get_editor_property("skeletal_mesh") != imported_skeletal_mesh:
-                            skel_mesh_comp.set_editor_property('skeletal_mesh', skeletal_mesh_asset)
+                        unreal.log("Replacing skeleton mesh component to alembic")
+                        unreal.log(skel_mesh_comp)
+                        if skel_mesh_comp:
+                            if skel_mesh_comp.get_editor_property("skeletal_mesh") != imported_skeletal_mesh:
+                                skel_mesh_comp.set_editor_property('skeletal_mesh', skeletal_mesh_asset)
 
 
 def set_sequence_frame_range(sequence, frameStart, frameEnd):


### PR DESCRIPTION
## Changelog Description
Add debug log to check skeletal mesh component when connecting alembic animation to level sequence performed. This is to make sure the unreal would look at the correct data for switching the skeletal mesh


## Additional info
n/a

## Testing notes:

1.Load Layout
2. Ayon -> Manage
3. Select animation(abc) and layout elements
4. Right click -> Actions -> Connecting Alembic Animation to Level Sequence
