### PR TITLE
Make sure the camera actor has name with version number with connect action

### DIFF
--- a/client/ayon_unreal/api/lib.py
+++ b/client/ayon_unreal/api/lib.py
@@ -99,8 +99,9 @@ def get_representation(parent_id, version_id):
         ), None)
 
 
-def import_camera_to_level_sequence(sequence, parent_id, version_id, world):
-     # Add a camera cut track to the sequence
+def import_camera_to_level_sequence(sequence, parent_id, version_id, container_name, world):
+    # Add a camera cut track to the sequence
+    camera_actor_name = container_name.replace("_CON", "")
     if not get_camera_tracks(sequence):
         sequence.add_master_track(unreal.MovieSceneCameraCutTrack)
     repre_entity = get_representation(parent_id, version_id)
@@ -125,3 +126,7 @@ def import_camera_to_level_sequence(sequence, parent_id, version_id, world):
             import_fbx_settings,
             camera_path
         )
+    camera_actors = unreal.GameplayStatics().get_all_actors_of_class(
+        world, unreal.CameraActor)
+    for actor in camera_actors:
+        actor.set_actor_label(camera_actor_name)

--- a/client/ayon_unreal/api/lib.py
+++ b/client/ayon_unreal/api/lib.py
@@ -113,12 +113,12 @@ def import_camera_to_level_sequence(sequence, parent_id, version_id, container_n
     if sel_actors:
         for actor in sel_actors:
             unreal.EditorLevelLibrary.destroy_actor(actor)
-        tracks = get_camera_tracks(sequence)
-        if tracks:
-            for track in tracks:
-                sections = track.get_sections()
-                for section in sections:
-                    track.remove_section(section)
+    tracks = get_camera_tracks(sequence)
+    if tracks:
+        for track in tracks:
+            sections = track.get_sections()
+            for section in sections:
+                track.remove_section(section)on)
     unreal.SequencerTools.import_level_sequence_fbx(
             world,
             sequence,

--- a/client/ayon_unreal/api/lib.py
+++ b/client/ayon_unreal/api/lib.py
@@ -99,9 +99,8 @@ def get_representation(parent_id, version_id):
         ), None)
 
 
-def import_camera_to_level_sequence(sequence, parent_id, version_id, container_name, world):
+def import_camera_to_level_sequence(sequence, parent_id, version_id, namespace, world):
     # Add a camera cut track to the sequence
-    camera_actor_name = container_name.replace("_CON", "")
     if not get_camera_tracks(sequence):
         sequence.add_master_track(unreal.MovieSceneCameraCutTrack)
     repre_entity = get_representation(parent_id, version_id)
@@ -128,5 +127,7 @@ def import_camera_to_level_sequence(sequence, parent_id, version_id, container_n
         )
     camera_actors = unreal.GameplayStatics().get_all_actors_of_class(
         world, unreal.CameraActor)
-    for actor in camera_actors:
-        actor.set_actor_label(camera_actor_name)
+    if namespace:
+        camera_actor_name = unreal.Paths.split(namespace)[1]
+        for actor in camera_actors:
+            actor.set_actor_label(camera_actor_name)

--- a/client/ayon_unreal/api/lib.py
+++ b/client/ayon_unreal/api/lib.py
@@ -118,7 +118,7 @@ def import_camera_to_level_sequence(sequence, parent_id, version_id, container_n
         for track in tracks:
             sections = track.get_sections()
             for section in sections:
-                track.remove_section(section)on)
+                track.remove_section(section)
     unreal.SequencerTools.import_level_sequence_fbx(
             world,
             sequence,

--- a/client/ayon_unreal/plugins/inventory/connect_animation_to_sequence.py
+++ b/client/ayon_unreal/plugins/inventory/connect_animation_to_sequence.py
@@ -98,8 +98,12 @@ class ConnectFbxAnimation(InventoryAction):
         version_id = next((
             container.get("representation") for container in containers
             if container.get("family") == "camera"), None)
+        container_name = next((
+            container.get("cotnainer_name") for container in containers
+            if container.get("family") == "camera"), None)
         layout_world = self.get_layout_asset(containers, asset_name="World")
-        import_camera_to_level_sequence(sequence, parent_id, version_id, layout_world)
+        import_camera_to_level_sequence(
+            sequence, parent_id, version_id, container_name, layout_world)
 
     def import_animation_sequence(self, asset_content, sequence, frameStart, frameEnd):
         import_animation_sequence(asset_content, sequence, frameStart, frameEnd)

--- a/client/ayon_unreal/plugins/inventory/connect_animation_to_sequence.py
+++ b/client/ayon_unreal/plugins/inventory/connect_animation_to_sequence.py
@@ -86,12 +86,6 @@ class ConnectFbxAnimation(InventoryAction):
             if container.get("family") == "camera"]
         if not has_camera_product:
             return
-        has_tracks = [
-            track for track in sequence.get_tracks()
-            if track.get_class() == unreal.MovieSceneCameraCutTrack.static_class()
-        ]
-        if has_tracks:
-            return
         parent_id = next((
             container.get("parent") for container in containers
             if container.get("family") == "camera"), None)

--- a/client/ayon_unreal/plugins/inventory/connect_animation_to_sequence.py
+++ b/client/ayon_unreal/plugins/inventory/connect_animation_to_sequence.py
@@ -98,12 +98,12 @@ class ConnectFbxAnimation(InventoryAction):
         version_id = next((
             container.get("representation") for container in containers
             if container.get("family") == "camera"), None)
-        container_name = next((
-            container.get("cotnainer_name") for container in containers
+        namespace = next((
+            container.get("namespace") for container in containers
             if container.get("family") == "camera"), None)
         layout_world = self.get_layout_asset(containers, asset_name="World")
         import_camera_to_level_sequence(
-            sequence, parent_id, version_id, container_name, layout_world)
+            sequence, parent_id, version_id, namespace, layout_world)
 
     def import_animation_sequence(self, asset_content, sequence, frameStart, frameEnd):
         import_animation_sequence(asset_content, sequence, frameStart, frameEnd)


### PR DESCRIPTION
## Changelog Description
This PR is to rename the name of the camera actor with version number after users performing connect fbx/alembic animation to level sequence
Possibly Resolve https://github.com/ynput/ayon-unreal/issues/116


## Additional info
n/a

## Testing notes:

1. Launch Unreal
2. Load layout, load camera, load animation
3. Ayon -> Manage -> Actions -> Connect fbx/alembic animation to level sequence
