### PR TITLE
Refactoring the format asset directory function

### DIFF
--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -26,7 +26,7 @@ class AnimationFBXLoader(plugin.Loader):
     color = "orange"
 
     root = unreal_pipeline.AYON_ROOT_DIR
-    loaded_asset_dir = "{folder[path]}/{product[name]}"
+    loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -404,9 +404,7 @@ class AnimationFBXLoader(plugin.Loader):
 
         path = self.filepath_from_context(context)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = unreal_pipeline.format_asset_directory(
-            name, context, self.loaded_asset_dir, extension=ext
-        )
+        asset_root, asset_name = unreal_pipeline.format_asset_directory(context, self.loaded_asset_dir)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix=f"_{ext}")
@@ -467,7 +465,6 @@ class AnimationFBXLoader(plugin.Loader):
         hierarchy = folder_path.lstrip("/").split("/")
         folder_name = hierarchy.pop(-1)
         folder_name = context["folder"]["name"]
-        product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         repre_entity = context["representation"]
         folder_entity = context["folder"]
@@ -475,9 +472,7 @@ class AnimationFBXLoader(plugin.Loader):
         suffix = "_CON"
         source_path = get_representation_path(repre_entity)
         ext = os.path.splitext(source_path)[-1].lstrip(".")
-        asset_root, asset_name = unreal_pipeline.format_asset_directory(
-            product_name, context, self.loaded_asset_dir, extension=ext
-        )
+        asset_root, asset_name = unreal_pipeline.format_asset_directory(context, self.loaded_asset_dir)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix=f"_{ext}")

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -245,7 +245,6 @@ class PointCacheAlembicLoader(plugin.Loader):
     def update(self, container, context):
         # Create directory for folder and Ayon container
         folder_path = context["folder"]["path"]
-        product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         repre_entity = context["representation"]
         asset_dir = container["namespace"]

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -29,7 +29,7 @@ class PointCacheAlembicLoader(plugin.Loader):
     color = "orange"
 
     abc_conversion_preset = "maya"
-    loaded_asset_dir = "{folder[path]}/{product[name]}"
+    loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -188,9 +188,7 @@ class PointCacheAlembicLoader(plugin.Loader):
         suffix = "_CON"
         path = self.filepath_from_context(context)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            name, context, self.loaded_asset_dir, extension=ext
-        )
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
@@ -254,8 +252,7 @@ class PointCacheAlembicLoader(plugin.Loader):
         suffix = "_CON"
         path = get_representation_path(repre_entity)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            product_name, context, self.loaded_asset_dir, extension=ext)
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix=f"_{ext}")

--- a/client/ayon_unreal/plugins/load/load_image_png.py
+++ b/client/ayon_unreal/plugins/load/load_image_png.py
@@ -30,7 +30,7 @@ class TexturePNGLoader(plugin.Loader):
     use_interchange = False
     show_dialog = False
     pipeline_path = ""
-    loaded_asset_dir = "{folder[path]}/{product[name]}"
+    loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -166,8 +166,7 @@ class TexturePNGLoader(plugin.Loader):
         suffix = "_CON"
         path = self.filepath_from_context(context)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            name, context, self.loaded_asset_dir, extension=ext)
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
@@ -210,7 +209,6 @@ class TexturePNGLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         repre_entity = context["representation"]
         path = get_representation_path(repre_entity)
@@ -218,8 +216,7 @@ class TexturePNGLoader(plugin.Loader):
 
         # Create directory for asset and Ayon container
         suffix = "_CON"
-        asset_root, asset_name = format_asset_directory(
-            product_name, context, self.loaded_asset_dir, extension=ext)
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -28,7 +28,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
     color = "orange"
 
     abc_conversion_preset = "maya"
-    loaded_asset_dir = "{folder[path]}/{product[name]}"
+    loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -198,9 +198,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         suffix = "_CON"
         path = self.filepath_from_context(context)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            name, context, self.loaded_asset_dir, extension=ext
-        )
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
 
         loaded_options = {
             "default_conversion": options.get("default_conversion", False),
@@ -261,8 +259,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         suffix = "_CON"
         path = get_representation_path(repre_entity)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            product_name, context, self.loaded_asset_dir, extension=ext)
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix=f"_{ext}")

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -251,7 +251,6 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         repre_entity = context["representation"]
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -182,7 +182,6 @@ class SkeletalMeshFBXLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         repre_entity = context["representation"]
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -25,7 +25,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    loaded_asset_dir = "{folder[path]}/{product[name]}"
+    loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -140,9 +140,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         suffix = "_CON"
         path = self.filepath_from_context(context)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            name, context, self.loaded_asset_dir, extension=ext
-        )
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
@@ -192,8 +190,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         suffix = "_CON"
         path = get_representation_path(repre_entity)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            product_name, context, self.loaded_asset_dir, extension=ext)
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix=f"_{ext}")

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -246,7 +246,6 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         repre_entity = context["representation"]
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -28,7 +28,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
     color = "orange"
 
     abc_conversion_preset = "maya"
-    loaded_asset_dir = "{folder[path]}/{product[name]}"
+    loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -200,9 +200,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
         suffix = "_CON"
         path = self.filepath_from_context(context)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            name, context, self.loaded_asset_dir, extension=ext
-        )
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
         loaded_options = {
             "default_conversion": options.get("default_conversion", False),
             "abc_conversion_preset": options.get(
@@ -256,8 +254,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
         suffix = "_CON"
         path = get_representation_path(repre_entity)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            product_name, context, self.loaded_asset_dir, extension=ext)
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix=f"_{ext}")

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -213,7 +213,6 @@ class StaticMeshFBXLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_name = context["product"]["name"]
         product_type = context["product"]["productType"]
         repre_entity = context["representation"]
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -29,7 +29,7 @@ class StaticMeshFBXLoader(plugin.Loader):
     use_nanite = True
     show_dialog = False
     pipeline_path = ""
-    loaded_asset_dir = "{folder[path]}/{product[name]}"
+    loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -170,9 +170,7 @@ class StaticMeshFBXLoader(plugin.Loader):
         suffix = "_CON"
         path = self.filepath_from_context(context)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            name, context, self.loaded_asset_dir, extension=ext
-        )
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
@@ -223,8 +221,7 @@ class StaticMeshFBXLoader(plugin.Loader):
         suffix = "_CON"
         path = get_representation_path(repre_entity)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = format_asset_directory(
-            product_name, context, self.loaded_asset_dir, extension=ext)
+        asset_root, asset_name = format_asset_directory(context, self.loaded_asset_dir)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix=f"_{ext}")

--- a/client/ayon_unreal/plugins/load/load_uasset.py
+++ b/client/ayon_unreal/plugins/load/load_uasset.py
@@ -24,7 +24,7 @@ class UAssetLoader(plugin.Loader):
 
     extension = "uasset"
 
-    loaded_asset_dir = "{folder[path]}/{product[name]}"
+    loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -55,21 +55,12 @@ class UAssetLoader(plugin.Loader):
         # Create directory for asset and Ayon container
         folder_path = context["folder"]["path"]
         suffix = "_CON"
-        asset_root, asset_name = unreal_pipeline.format_asset_directory(
-            name, context, self.loaded_asset_dir, use_version=False)
+        asset_root, asset_name = unreal_pipeline.format_asset_directory(context, self.loaded_asset_dir)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix=""
         )
-
-        unique_number = 1
-        while unreal.EditorAssetLibrary.does_directory_exist(
-            f"{asset_dir}_{unique_number:02}"
-        ):
-            unique_number += 1
-
-        asset_dir = f"{asset_dir}_{unique_number:02}"
-        container_name = f"{container_name}_{unique_number:02}{suffix}"
+        container_name = f"{container_name}_{suffix}"
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             unreal.EditorAssetLibrary.make_directory(asset_dir)
 

--- a/client/ayon_unreal/plugins/load/load_yeticache.py
+++ b/client/ayon_unreal/plugins/load/load_yeticache.py
@@ -20,8 +20,7 @@ class YetiLoader(plugin.Loader):
     icon = "pagelines"
     color = "orange"
 
-    loaded_asset_dir = "{folder[path]}/{product[name]}"
-
+    loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
     @classmethod
     def apply_settings(cls, project_settings):
         super(YetiLoader, cls).apply_settings(project_settings)
@@ -100,21 +99,13 @@ class YetiLoader(plugin.Loader):
         suffix = "_CON"
         path = self.filepath_from_context(context)
         ext = os.path.splitext(path)[-1].lstrip(".")
-        asset_root, asset_name = unreal_pipeline.format_asset_directory(
-            name, context, self.loaded_asset_dir, extension=ext)
+        asset_root, asset_name = unreal_pipeline.format_asset_directory(context, self.loaded_asset_dir)
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix=f"_{ext}")
 
-        unique_number = 1
-        while unreal.EditorAssetLibrary.does_directory_exist(
-            f"{asset_dir}_{unique_number:02}"
-        ):
-            unique_number += 1
-
-        asset_dir = f"{asset_dir}_{unique_number:02}"
-        container_name = f"{container_name}_{unique_number:02}{suffix}"
+        container_name = f"{container_name}_{suffix}"
         asset_path = unreal_pipeline.has_asset_directory_pattern_matched(
             asset_name, asset_dir, name)
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):

--- a/server/settings.py
+++ b/server/settings.py
@@ -45,7 +45,7 @@ class UnrealSettings(BaseSettingsModel):
         title="Color Management (ImageIO)"
     )
     loaded_asset_dir: str = SettingsField(
-        "{folder[path]}/{product[name]}",
+        "{folder[path]}/{product[name]}_{version[version]}",
         title="Asset directories for loaded assets",
         description="Asset directories to store the loaded assets"
     )
@@ -114,7 +114,7 @@ class UnrealSettings(BaseSettingsModel):
 
 
 DEFAULT_VALUES = {
-    "loaded_asset_dir": "{folder[path]}/{product[name]}",
+    "loaded_asset_dir": "{folder[path]}/{product[name]}_{version[version]}",
     "level_sequences_for_layouts": True,
     "remove_loaded_assets": False,
     "delete_unmatched_assets": False,


### PR DESCRIPTION
## Changelog Description
This PR is to refactor the `format_asset_directory` function so that users can have more freedom to customize their directories for loading the assets.


## Additional info
n/a


## Testing notes:

1. Build and install the unreal addon with this branch
2. Launch Unreal
3. Change your loaded asset template to your own preferences in `ayon+settings://unreal/loaded_asset_dir` in ayon setting
4. Load Assets