### PR TITLE
Check if the render path exists in render instance collector

### DIFF
--- a/client/ayon_unreal/plugins/publish/collect_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/collect_render_instances.py
@@ -106,7 +106,7 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
                     if not os.path.exists(render_path):
                         raise RuntimeError(
                             "Render directory not found. "
-                            "Please render with the AyonPublishInstance."
+                            "Please render with the render instance."
                         )
                     self.log.debug(f"Collecting render path: {render_path}")
                     frames = [str(x) for x in render_path.iterdir() if x.is_file()]

--- a/client/ayon_unreal/plugins/publish/collect_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/collect_render_instances.py
@@ -103,6 +103,11 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
 
                     render_dir = f"{root}/{project}/{s.get('output')}"
                     render_path = Path(render_dir)
+                    if not os.path.exists(render_path):
+                        raise RuntimeError(
+                            "Render directory not found. "
+                            "Please render with the AyonPublishInstance."
+                        )
                     self.log.debug(f"Collecting render path: {render_path}")
                     frames = [str(x) for x in render_path.iterdir() if x.is_file()]
                     frames = pipeline.get_sequence(frames)


### PR DESCRIPTION
## Changelog Description
This PR is to check whether the render path exists in render instance collector. If it doesn't exist, it will raise Exception to inform the users that the related directory is not found and they need to render with ayon publish instance first to have the render directory.


## Additional info
n/a


## Testing notes:

1. Launch Unreal
2. Create Render Instance 
3. Publish with the options of farm rendering.
