### PR TITLE
Correct hierarchy import for layout loader 

### DIFF
--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -1052,3 +1052,18 @@ def has_asset_directory_pattern_matched(asset_name, asset_dir, name, extension=N
         return asset_path
 
     return None
+
+
+def get_top_hierarchy_folder(path):
+    """Get top hierarchy of the path
+
+    Args:
+        path (str): path
+
+    Returns:
+        str: top hierarchy directory
+    """
+    # Split the path by the directory separator '/'
+    parts = path.split('/')
+    # Return the first part
+    return parts[0]

--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -1064,6 +1064,7 @@ def get_top_hierarchy_folder(path):
         str: top hierarchy directory
     """
     # Split the path by the directory separator '/'
-    parts = path.split('/')
+    path = path.replace(f"{AYON_ROOT_DIR}/", "")
     # Return the first part
+    parts = [part for part in path.split('/') if part]
     return parts[0]

--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -854,8 +854,6 @@ def format_asset_directory(context, directory_template):
         context (dict): context
         directory_template (str): directory template path
         extension (str, optional): file extension. Defaults to "abc".
-        use_version (bool, optional): use context version for asset
-            directory. Defaults to True.
     Returns:
         tuple[str, str]: asset directory, asset name
     """

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -29,9 +29,22 @@ class CameraLoader(plugin.Loader):
     representations = {"fbx"}
     icon = "cube"
     color = "orange"
-    root = AYON_ROOT_DIR
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
     master_dir = "{project[name]}"
+
+    @classmethod
+    def apply_settings(cls, project_settings):
+        super(CameraLoader, cls).apply_settings(
+            project_settings
+        )
+        cls.loaded_layout_dir = (
+            project_settings["unreal"].get(
+                "loaded_layout_dir", cls.loaded_layout_dir)
+        )
+        cls.master_dir = (
+            project_settings["unreal"].get(
+                "master_dir", cls.master_dir)
+        )
 
     def _import_camera(
         self, world, sequence, bindings, import_fbx_settings, import_filename
@@ -208,7 +221,7 @@ class CameraLoader(plugin.Loader):
                             key.set_time(unreal.FrameNumber(value=new_time))
         return master_level
 
-    def load(self, context, name, namespace, data):
+    def load(self, context, name, namespace, options):
         """
         Load and containerise representation into Content Browser.
 
@@ -346,8 +359,8 @@ class CameraLoader(plugin.Loader):
         asset_dir = container.get('namespace')
         # Create a temporary level to delete the layout level.
         EditorLevelLibrary.save_all_dirty_levels()
-        EditorAssetLibrary.make_directory(f"{self.root}/tmp")
-        tmp_level = f"{self.root}/tmp/temp_map"
+        EditorAssetLibrary.make_directory(f"{AYON_ROOT_DIR}/tmp")
+        tmp_level = f"{AYON_ROOT_DIR}/tmp/temp_map"
         if not EditorAssetLibrary.does_asset_exist(f"{tmp_level}.temp_map"):
             EditorLevelLibrary.new_level(tmp_level)
         else:
@@ -359,4 +372,4 @@ class CameraLoader(plugin.Loader):
         # Load the default level
         default_level_path = "/Engine/Maps/Templates/OpenWorld"
         EditorLevelLibrary.load_level(default_level_path)
-        EditorAssetLibrary.delete_directory(f"{self.root}/tmp")
+        EditorAssetLibrary.delete_directory(f"{AYON_ROOT_DIR}/tmp")

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -99,12 +99,12 @@ class CameraLoader(plugin.Loader):
         imprint(f"{asset_dir}/{container_name}", data)
 
     def _create_map_camera(self, context, path, tools, hierarchy_dir,
-                           master_dir, asset_dir, asset_name):
+                           master_dir_name, asset_dir, asset_name):
         # Create map for the shot, and create hierarchy of map. If the maps
         # already exist, we will use them.
-        master_level = f"{hierarchy_dir}/{master_dir}_map.{master_dir}_map"
+        master_level = f"{hierarchy_dir}/{master_dir_name}_map.{master_dir_name}_map"
         if not EditorAssetLibrary.does_asset_exist(master_level):
-            EditorLevelLibrary.new_level(f"{hierarchy_dir}/{master_dir}_map")
+            EditorLevelLibrary.new_level(f"{hierarchy_dir}/{master_dir_name}_map")
 
         level = (
             f"{asset_dir}/{asset_name}_map_camera.{asset_name}_map_camera"
@@ -146,7 +146,7 @@ class CameraLoader(plugin.Loader):
                     seq.get_asset().get_playback_end()))
         else:
             sequence, frame_range = generate_sequence(
-                master_dir, hierarchy_dir)
+                master_dir_name, hierarchy_dir)
 
             sequences.append(sequence)
             frame_ranges.append(frame_range)
@@ -245,12 +245,10 @@ class CameraLoader(plugin.Loader):
         folder_name = folder_entity["name"]
         asset_root, asset_name = format_asset_directory(
             context, self.loaded_asset_dir)
-        master_dir = get_top_hierarchy_folder(asset_root)
-        hierarchy_dir, _ = format_asset_directory(context, master_dir)
+        master_dir_name = get_top_hierarchy_folder(asset_root)
+        hierarchy_dir = f"{AYON_ROOT_DIR}/{master_dir_name}"
         suffix = "_CON"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
-        unreal.log("asset_root")
-        unreal.log(asset_root)
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix="")
 
@@ -261,7 +259,7 @@ class CameraLoader(plugin.Loader):
             path = self.filepath_from_context(context)
             master_level = self._create_map_camera(
                 context, path, tools, hierarchy_dir,
-                master_dir, asset_dir, asset_name
+                master_dir_name, asset_dir, asset_name
             )
 
         # Create Asset Container
@@ -302,8 +300,8 @@ class CameraLoader(plugin.Loader):
         folder_path = folder_entity["path"]
         asset_root, asset_name = format_asset_directory(
             context, self.loaded_asset_dir)
-        master_dir = get_top_hierarchy_folder(asset_root)
-        hierarchy_dir, _ = format_asset_directory(context, master_dir)
+        master_dir_name = get_top_hierarchy_folder(asset_root)
+        hierarchy_dir = f"{AYON_ROOT_DIR}/{master_dir_name}"
         suffix = "_CON"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
@@ -316,7 +314,7 @@ class CameraLoader(plugin.Loader):
             path = get_representation_path(repre_entity)
             master_level = self._create_map_camera(
                 context, path, tools, hierarchy_dir,
-                master_dir, asset_dir, asset_name
+                master_dir_name, asset_dir, asset_name
             )
 
         # Create Asset Container

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -37,9 +37,9 @@ class CameraLoader(plugin.Loader):
         super(CameraLoader, cls).apply_settings(
             project_settings
         )
-        cls.loaded_layout_dir = (
+        cls.loaded_asset_dir = (
             project_settings["unreal"].get(
-                "loaded_layout_dir", cls.loaded_layout_dir)
+                "loaded_asset_dir", cls.loaded_asset_dir)
         )
         cls.master_dir = (
             project_settings["unreal"].get(

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -243,13 +243,14 @@ class CameraLoader(plugin.Loader):
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
         folder_name = folder_entity["name"]
-        master_dir = get_top_hierarchy_folder(self.loaded_asset_dir)
+        asset_root, asset_name = format_asset_directory(
+            context, self.loaded_asset_dir)
+        master_dir = get_top_hierarchy_folder(asset_root)
         hierarchy_dir, _ = format_asset_directory(context, master_dir)
         suffix = "_CON"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
-
-        asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir)
+        unreal.log("asset_root")
+        unreal.log(asset_root)
         asset_dir, container_name = tools.create_unique_asset_name(
             asset_root, suffix="")
 
@@ -299,10 +300,10 @@ class CameraLoader(plugin.Loader):
         repre_entity = context["representation"]
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
-        master_dir = get_top_hierarchy_folder(self.loaded_asset_dir)
-        hierarchy_dir, _ = format_asset_directory(context, master_dir)
         asset_root, asset_name = format_asset_directory(
             context, self.loaded_asset_dir)
+        master_dir = get_top_hierarchy_folder(asset_root)
+        hierarchy_dir, _ = format_asset_directory(context, master_dir)
         suffix = "_CON"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -299,7 +299,6 @@ class CameraLoader(plugin.Loader):
         repre_entity = context["representation"]
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
-        project_name = context["project"]["name"]
         master_dir = get_top_hierarchy_folder(self.loaded_asset_dir)
         hierarchy_dir, _ = format_asset_directory(context, master_dir)
         asset_root, asset_name = format_asset_directory(

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -17,7 +17,8 @@ from ayon_unreal.api.pipeline import (
     create_container,
     imprint,
     format_asset_directory,
-    AYON_ROOT_DIR
+    AYON_ROOT_DIR,
+    get_top_hierarchy_folder
 )
 
 
@@ -30,7 +31,6 @@ class CameraLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
-    master_dir = "{project[name]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -40,10 +40,6 @@ class CameraLoader(plugin.Loader):
         cls.loaded_asset_dir = (
             project_settings["unreal"].get(
                 "loaded_asset_dir", cls.loaded_asset_dir)
-        )
-        cls.master_dir = (
-            project_settings["unreal"].get(
-                "master_dir", cls.master_dir)
         )
 
     def _import_camera(
@@ -248,8 +244,8 @@ class CameraLoader(plugin.Loader):
         folder_path = folder_entity["path"]
         folder_name = folder_entity["name"]
         project_name = context["project"]["name"]
-
-        hierarchy_dir, _ = format_asset_directory(context, self.master_dir)
+        master_dir = get_top_hierarchy_folder(self.loaded_asset_dir)
+        hierarchy_dir, _ = format_asset_directory(context, master_dir)
         suffix = "_CON"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
 
@@ -305,7 +301,8 @@ class CameraLoader(plugin.Loader):
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
         project_name = context["project"]["name"]
-        hierarchy_dir, _ = format_asset_directory(context, self.master_dir)
+        master_dir = get_top_hierarchy_folder(self.loaded_asset_dir)
+        hierarchy_dir, _ = format_asset_directory(context, master_dir)
         asset_root, asset_name = format_asset_directory(
             context, self.loaded_asset_dir)
         suffix = "_CON"

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -99,12 +99,12 @@ class CameraLoader(plugin.Loader):
         imprint(f"{asset_dir}/{container_name}", data)
 
     def _create_map_camera(self, context, path, tools, hierarchy_dir,
-                           project_name, asset_dir, asset_name):
+                           master_dir, asset_dir, asset_name):
         # Create map for the shot, and create hierarchy of map. If the maps
         # already exist, we will use them.
-        master_level = f"{hierarchy_dir}/{project_name}_map.{project_name}_map"
+        master_level = f"{hierarchy_dir}/{master_dir}_map.{master_dir}_map"
         if not EditorAssetLibrary.does_asset_exist(master_level):
-            EditorLevelLibrary.new_level(f"{hierarchy_dir}/{project_name}_map")
+            EditorLevelLibrary.new_level(f"{hierarchy_dir}/{master_dir}_map")
 
         level = (
             f"{asset_dir}/{asset_name}_map_camera.{asset_name}_map_camera"
@@ -146,7 +146,7 @@ class CameraLoader(plugin.Loader):
                     seq.get_asset().get_playback_end()))
         else:
             sequence, frame_range = generate_sequence(
-                project_name, hierarchy_dir)
+                master_dir, hierarchy_dir)
 
             sequences.append(sequence)
             frame_ranges.append(frame_range)
@@ -243,7 +243,6 @@ class CameraLoader(plugin.Loader):
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
         folder_name = folder_entity["name"]
-        project_name = context["project"]["name"]
         master_dir = get_top_hierarchy_folder(self.loaded_asset_dir)
         hierarchy_dir, _ = format_asset_directory(context, master_dir)
         suffix = "_CON"
@@ -261,7 +260,7 @@ class CameraLoader(plugin.Loader):
             path = self.filepath_from_context(context)
             master_level = self._create_map_camera(
                 context, path, tools, hierarchy_dir,
-                project_name, asset_dir, asset_name
+                master_dir, asset_dir, asset_name
             )
 
         # Create Asset Container
@@ -317,7 +316,7 @@ class CameraLoader(plugin.Loader):
             path = get_representation_path(repre_entity)
             master_level = self._create_map_camera(
                 context, path, tools, hierarchy_dir,
-                project_name, asset_dir, asset_name
+                master_dir, asset_dir, asset_name
             )
 
         # Create Asset Container

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -645,7 +645,7 @@ class LayoutLoader(plugin.Loader):
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else name
         asset_root, _ = format_asset_directory(context, self.loaded_layout_dir)
-        master_dir = get_top_hierarchy_folder(self.loaded_layout_dir)
+        master_dir = get_top_hierarchy_folder(asset_root)
         hierarchy_dir, _ = format_asset_directory(context, master_dir)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(asset_root, suffix="")
@@ -812,7 +812,7 @@ class LayoutLoader(plugin.Loader):
         master_level = None
         hierarchy_dir = container.get("master_directory", "")
         if not hierarchy_dir:
-            master_dir = get_top_hierarchy_folder(self.loaded_layout_dir)
+            master_dir = get_top_hierarchy_folder(asset_dir)
             hierarchy_dir, _ = format_asset_directory(context, master_dir)
         if create_sequences:
             h_asset = context["project"]["name"]

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -645,8 +645,8 @@ class LayoutLoader(plugin.Loader):
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else name
         asset_root, _ = format_asset_directory(context, self.loaded_layout_dir)
-        master_dir = get_top_hierarchy_folder(asset_root)
-        hierarchy_dir, _ = format_asset_directory(context, master_dir)
+        master_dir_name = get_top_hierarchy_folder(asset_root)
+        hierarchy_dir = f"{AYON_ROOT_DIR}/{asset_root}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(asset_root, suffix="")
 
@@ -664,9 +664,9 @@ class LayoutLoader(plugin.Loader):
         if create_sequences:
             # Create map for the shot, and create hierarchy of map. If the
             # maps already exist, we will use them.
-            master_level = f"{hierarchy_dir}/{master_dir}_map.{master_dir}_map"
+            master_level = f"{hierarchy_dir}/{hierarchy_dir}_map.{master_dir_name}_map"
             if not EditorAssetLibrary.does_asset_exist(master_level):
-                EditorLevelLibrary.new_level(f"{hierarchy_dir}/{master_dir}_map")
+                EditorLevelLibrary.new_level(f"{hierarchy_dir}/{master_dir_name}_map")
             if master_level:
                 EditorLevelLibrary.load_level(master_level)
                 EditorLevelUtils.add_level_to_world(
@@ -691,7 +691,7 @@ class LayoutLoader(plugin.Loader):
             ]
 
             if not existing_sequences:
-                sequence, frame_range = generate_sequence(master_dir, hierarchy_dir)
+                sequence, frame_range = generate_sequence(master_dir_name, hierarchy_dir)
 
                 sequences.append(sequence)
                 frame_ranges.append(frame_range)
@@ -812,8 +812,8 @@ class LayoutLoader(plugin.Loader):
         master_level = None
         hierarchy_dir = container.get("master_directory", "")
         if not hierarchy_dir:
-            master_dir = get_top_hierarchy_folder(asset_dir)
-            hierarchy_dir, _ = format_asset_directory(context, master_dir)
+            master_dir_name = get_top_hierarchy_folder(asset_dir)
+            hierarchy_dir = f"{AYON_ROOT_DIR}/{master_dir_name}"
         if create_sequences:
             h_asset = context["project"]["name"]
             master_level = f"{hierarchy_dir}/{h_asset}_map.{h_asset}_map"

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -640,7 +640,6 @@ class LayoutLoader(plugin.Loader):
         # Create directory for asset and Ayon container
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
-        project_name = context["project"]["name"]
         # Remove folder name
         folder_name = folder_entity["name"]
         suffix = "_CON"
@@ -665,9 +664,9 @@ class LayoutLoader(plugin.Loader):
         if create_sequences:
             # Create map for the shot, and create hierarchy of map. If the
             # maps already exist, we will use them.
-            master_level = f"{hierarchy_dir}/{project_name}_map.{project_name}_map"
+            master_level = f"{hierarchy_dir}/{master_dir}_map.{master_dir}_map"
             if not EditorAssetLibrary.does_asset_exist(master_level):
-                EditorLevelLibrary.new_level(f"{hierarchy_dir}/{project_name}_map")
+                EditorLevelLibrary.new_level(f"{hierarchy_dir}/{master_dir}_map")
             if master_level:
                 EditorLevelLibrary.load_level(master_level)
                 EditorLevelUtils.add_level_to_world(
@@ -692,7 +691,7 @@ class LayoutLoader(plugin.Loader):
             ]
 
             if not existing_sequences:
-                sequence, frame_range = generate_sequence(project_name, hierarchy_dir)
+                sequence, frame_range = generate_sequence(master_dir, hierarchy_dir)
 
                 sequences.append(sequence)
                 frame_ranges.append(frame_range)

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -646,7 +646,7 @@ class LayoutLoader(plugin.Loader):
         asset_name = f"{folder_name}_{name}" if folder_name else name
         asset_root, _ = format_asset_directory(context, self.loaded_layout_dir)
         master_dir_name = get_top_hierarchy_folder(asset_root)
-        hierarchy_dir = f"{AYON_ROOT_DIR}/{asset_root}"
+        hierarchy_dir = f"{AYON_ROOT_DIR}/{master_dir_name}"
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(asset_root, suffix="")
 
@@ -664,7 +664,7 @@ class LayoutLoader(plugin.Loader):
         if create_sequences:
             # Create map for the shot, and create hierarchy of map. If the
             # maps already exist, we will use them.
-            master_level = f"{hierarchy_dir}/{hierarchy_dir}_map.{master_dir_name}_map"
+            master_level = f"{hierarchy_dir}/{master_dir_name}_map.{master_dir_name}_map"
             if not EditorAssetLibrary.does_asset_exist(master_level):
                 EditorLevelLibrary.new_level(f"{hierarchy_dir}/{master_dir_name}_map")
             if master_level:
@@ -815,9 +815,7 @@ class LayoutLoader(plugin.Loader):
             master_dir_name = get_top_hierarchy_folder(asset_dir)
             hierarchy_dir = f"{AYON_ROOT_DIR}/{master_dir_name}"
         if create_sequences:
-            h_asset = context["project"]["name"]
-            master_level = f"{hierarchy_dir}/{h_asset}_map.{h_asset}_map"
-
+            master_level = f"{hierarchy_dir}/{master_dir_name}_map.{master_dir_name}_map"
             filter = unreal.ARFilter(
                 class_names=["LevelSequence"],
                 package_paths=[asset_dir],

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -34,7 +34,8 @@ from ayon_unreal.api.pipeline import (
     imprint,
     ls,
     AYON_ROOT_DIR,
-    format_asset_directory
+    format_asset_directory,
+    get_top_hierarchy_folder
 )
 from ayon_core.lib import EnumDef
 
@@ -80,7 +81,6 @@ class LayoutLoader(plugin.Loader):
     folder_representation_type = "json"
     force_loaded = False
     loaded_layout_dir = "{folder[path]}/{product[name]}"
-    master_dir = "{project[name]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -93,15 +93,13 @@ class LayoutLoader(plugin.Loader):
         # Apply import settings
         loaded_layout_dir = unreal_settings.get(
             "loaded_layout_dir", cls.loaded_layout_dir)
-        master_dir = unreal_settings.get("master_dir", cls.master_dir)
+
         if folder_representation_type:
             cls.folder_representation_type = folder_representation_type
         if use_force_loaded:
             cls.force_loaded = use_force_loaded
         if loaded_layout_dir:
             cls.loaded_layout_dir = loaded_layout_dir
-        if master_dir:
-            cls.master_dir = master_dir
 
     @classmethod
     def get_options(cls, contexts):
@@ -648,7 +646,8 @@ class LayoutLoader(plugin.Loader):
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else name
         asset_root, _ = format_asset_directory(context, self.loaded_layout_dir)
-        hierarchy_dir, _ = format_asset_directory(context, self.master_dir)
+        master_dir = get_top_hierarchy_folder(self.loaded_layout_dir)
+        hierarchy_dir, _ = format_asset_directory(context, master_dir)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(asset_root, suffix="")
 
@@ -814,7 +813,8 @@ class LayoutLoader(plugin.Loader):
         master_level = None
         hierarchy_dir = container.get("master_directory", "")
         if not hierarchy_dir:
-            hierarchy_dir, _ = format_asset_directory(context, self.master_dir)
+            master_dir = get_top_hierarchy_folder(self.loaded_layout_dir)
+            hierarchy_dir, _ = format_asset_directory(context, master_dir)
         if create_sequences:
             h_asset = context["project"]["name"]
             master_level = f"{hierarchy_dir}/{h_asset}_map.{h_asset}_map"

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -917,7 +917,7 @@ class LayoutLoader(plugin.Loader):
             # We need to traverse the hierarchy from the master sequence to
             # find the level sequence.
             master_directory = container.get("master_directory", "")
-            if not ms_asset:
+            if not master_directory:
                 namespace = container.get('namespace').replace(f"{root}/", "")
                 ms_asset = namespace.split('/')[0]
                 master_directory = f"{root}/{ms_asset}"

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -85,18 +85,23 @@ class LayoutLoader(plugin.Loader):
     @classmethod
     def apply_settings(cls, project_settings):
         super(LayoutLoader, cls).apply_settings(project_settings)
-
+        unreal_settings =  project_settings.get("unreal", {})
         # Apply import settings
-        folder_representation_type = (
-            project_settings.get("unreal", {}).get("folder_representation_type", {})
-        )
-        use_force_loaded = (
-            project_settings.get("unreal", {}).get("force_loaded", {})
-        )
+        folder_representation_type = unreal_settings.get(
+            "folder_representation_type", {})
+        use_force_loaded = unreal_settings.get("force_loaded", {})
+        # Apply import settings
+        loaded_layout_dir = unreal_settings.get(
+            "loaded_layout_dir", cls.loaded_layout_dir)
+        master_dir = unreal_settings.get("master_dir", cls.master_dir)
         if folder_representation_type:
             cls.folder_representation_type = folder_representation_type
         if use_force_loaded:
             cls.force_loaded = use_force_loaded
+        if loaded_layout_dir:
+            cls.loaded_layout_dir = loaded_layout_dir
+        if master_dir:
+            cls.master_dir = master_dir
 
     @classmethod
     def get_options(cls, contexts):

--- a/client/ayon_unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_unreal/plugins/load/load_layout_existing.py
@@ -28,7 +28,6 @@ class ExistingLayoutLoader(plugin.Loader):
     label = "Load Layout on Existing Scene"
     icon = "code-fork"
     color = "orange"
-    ASSET_ROOT = "/Game/Ayon"
 
     delete_unmatched_assets = True
     loaded_layout_dir = "{folder[path]}/{product[name]}"
@@ -41,6 +40,14 @@ class ExistingLayoutLoader(plugin.Loader):
         )
         cls.delete_unmatched_assets = (
             project_settings["unreal"]["delete_unmatched_assets"]
+        )
+        cls.loaded_layout_dir = (
+            project_settings["unreal"].get(
+                "loaded_layout_dir", cls.loaded_layout_dir)
+        )
+        cls.master_dir = (
+            project_settings["unreal"].get(
+                "master_dir", cls.master_dir)
         )
 
     @staticmethod

--- a/client/ayon_unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_unreal/plugins/load/load_layout_existing.py
@@ -31,7 +31,6 @@ class ExistingLayoutLoader(plugin.Loader):
 
     delete_unmatched_assets = True
     loaded_layout_dir = "{folder[path]}/{product[name]}"
-    master_dir = "{project[name]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -44,10 +43,6 @@ class ExistingLayoutLoader(plugin.Loader):
         cls.loaded_layout_dir = (
             project_settings["unreal"].get(
                 "loaded_layout_dir", cls.loaded_layout_dir)
-        )
-        cls.master_dir = (
-            project_settings["unreal"].get(
-                "master_dir", cls.master_dir)
         )
 
     @staticmethod

--- a/client/ayon_unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_unreal/plugins/load/load_layout_existing.py
@@ -31,6 +31,8 @@ class ExistingLayoutLoader(plugin.Loader):
     ASSET_ROOT = "/Game/Ayon"
 
     delete_unmatched_assets = True
+    loaded_layout_dir = "{folder[path]}/{product[name]}"
+    master_dir = "{project[name]}"
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -403,23 +405,17 @@ class ExistingLayoutLoader(plugin.Loader):
         # Create directory for asset and Ayon container
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
-        hierarchy = folder_path.lstrip("/").split("/")
-        # Remove folder name
-        folder_name = hierarchy.pop(-1) if len(hierarchy) > 0 else hierarchy
-        product_type = context["product"]["productType"]
-        root = self.ASSET_ROOT
-        hierarchy_dir = root
-        hierarchy_dir_list = []
-        for h in hierarchy:
-            hierarchy_dir = f"{hierarchy_dir}/{h}"
-            hierarchy_dir_list.append(hierarchy_dir)
 
+        folder_name = folder_entity["name"]
+        product_type = context["product"]["productType"]
+        asset_root, _ = upipeline.format_asset_directory(
+            context, self.loaded_layout_dir)
         suffix = "_CON"
         asset_name = f"{folder_name}_{name}" if folder_name else name
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            "{}/{}/{}".format(hierarchy_dir, folder_name, name),
+            asset_root,
             suffix="_existing"
         )
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -42,7 +42,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         cls.show_dialog = import_settings.get("show_dialog", cls.show_dialog)
 
     @staticmethod
-    def get_task(cls, filename, asset_dir, asset_name, replace):
+    def get_task(filename, asset_dir, asset_name, replace):
         task = unreal.AssetImportTask()
         options = unreal.FbxImportUI()
 
@@ -79,6 +79,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
 
         return task
 
+
     def import_and_containerize(
         self, filepath, asset_dir, asset_name, container_name,
         asset_path=None
@@ -86,7 +87,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         task = None
         if asset_path:
             loaded_asset_dir = unreal.Paths.split(asset_path)[0]
-            task = self.get_task(filepath, loaded_asset_dir, asset_name, True)
+            task =self.get_task(filepath, loaded_asset_dir, asset_name, False)
         else:
             if not unreal.EditorAssetLibrary.does_asset_exist(
                 f"{asset_dir}/{asset_name}"):

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -41,8 +41,8 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         )
         cls.show_dialog = import_settings.get("show_dialog", cls.show_dialog)
 
-    @staticmethod
-    def get_task(filename, asset_dir, asset_name, replace):
+    @classmethod
+    def get_task(cls, filename, asset_dir, asset_name, replace):
         task = unreal.AssetImportTask()
         options = unreal.FbxImportUI()
 
@@ -87,7 +87,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         task = None
         if asset_path:
             loaded_asset_dir = unreal.Paths.split(asset_path)[0]
-            task =self.get_task(filepath, loaded_asset_dir, asset_name, False)
+            task = self.get_task(filepath, loaded_asset_dir, asset_name, False)
         else:
             if not unreal.EditorAssetLibrary.does_asset_exist(
                 f"{asset_dir}/{asset_name}"):

--- a/server/settings.py
+++ b/server/settings.py
@@ -49,6 +49,16 @@ class UnrealSettings(BaseSettingsModel):
         title="Asset directories for loaded assets",
         description="Asset directories to store the loaded assets"
     )
+    loaded_layout_dir: str = SettingsField(
+        "{folder[path]}/{product[name]}",
+        title="Directories for loaded layouts",
+        description="Directories to store the loaded layouts or cameras"
+    )
+    master_dir: str = SettingsField(
+        "{project[name]}",
+        title="Parent Directories for loaded layouts",
+        description="Parent directories for the loaded layouts"
+    )
     import_settings: UnrealImportModel = SettingsField(
         default_factory=UnrealImportModel,
         title="Import settings"
@@ -115,6 +125,8 @@ class UnrealSettings(BaseSettingsModel):
 
 DEFAULT_VALUES = {
     "loaded_asset_dir": "{folder[path]}/{product[name]}_{version[version]}",
+    "loaded_layout_dir": "{folder[path]}/{product[name]}",
+    "master_dir": "{project[name]}",
     "level_sequences_for_layouts": True,
     "remove_loaded_assets": False,
     "delete_unmatched_assets": False,

--- a/server/settings.py
+++ b/server/settings.py
@@ -52,7 +52,7 @@ class UnrealSettings(BaseSettingsModel):
     loaded_layout_dir: str = SettingsField(
         "{folder[path]}/{product[name]}",
         title="Directories for loaded layouts",
-        description="Directories to store the loaded layouts or cameras"
+        description="Directories to store the loaded layouts"
     )
     master_dir: str = SettingsField(
         "{project[name]}",

--- a/server/settings.py
+++ b/server/settings.py
@@ -54,11 +54,6 @@ class UnrealSettings(BaseSettingsModel):
         title="Directories for loaded layouts",
         description="Directories to store the loaded layouts"
     )
-    master_dir: str = SettingsField(
-        "{project[name]}",
-        title="Parent Directories for loaded layouts",
-        description="Parent directories for the loaded layouts"
-    )
     import_settings: UnrealImportModel = SettingsField(
         default_factory=UnrealImportModel,
         title="Import settings"
@@ -126,7 +121,6 @@ class UnrealSettings(BaseSettingsModel):
 DEFAULT_VALUES = {
     "loaded_asset_dir": "{folder[path]}/{product[name]}_{version[version]}",
     "loaded_layout_dir": "{folder[path]}/{product[name]}",
-    "master_dir": "{project[name]}",
     "level_sequences_for_layouts": True,
     "remove_loaded_assets": False,
     "delete_unmatched_assets": False,


### PR DESCRIPTION
## Changelog Description
This PR is to tweak the correct hierarchy import for the layout loader. It also supports customize settings for storing the master sequence and layout respectively. Besides, it makes sure the camera loader following the existing pattern of the asset hierarchies (version folder), and the camera living in the loaded map would be renamed accordingly.
![image](https://github.com/user-attachments/assets/b7745fb4-853e-400c-8899-34d5ccacbaa9)

Resolve https://github.com/ynput/ayon-unreal/issues/136


## Additional info
Please build and install unreal addon with this branch

## Testing notes:

1. Tweak settings in `ayon+settings://unreal/loaded_asset_dir` and `ayon+settings://unreal/loaded_layout_dir`
2. Launch Unreal
3. Load Layout/Layout Existing/Camera/
