### PR TITLE
add playback frame range when importing camera

### DIFF
--- a/client/ayon_unreal/api/lib.py
+++ b/client/ayon_unreal/api/lib.py
@@ -99,7 +99,9 @@ def get_representation(parent_id, version_id):
         ), None)
 
 
-def import_camera_to_level_sequence(sequence, parent_id, version_id, namespace, world):
+def import_camera_to_level_sequence(sequence, parent_id, version_id,
+                                    namespace, world, frameStart,
+                                    frameEnd):
     # Add a camera cut track to the sequence
     if not get_camera_tracks(sequence):
         sequence.add_master_track(unreal.MovieSceneCameraCutTrack)
@@ -132,3 +134,5 @@ def import_camera_to_level_sequence(sequence, parent_id, version_id, namespace, 
         unreal.log(f"Spawning camera: {camera_actor_name}")
         for actor in camera_actors:
             actor.set_actor_label(camera_actor_name)
+
+    set_sequence_frame_range(sequence, frameStart, frameEnd)

--- a/client/ayon_unreal/plugins/inventory/connect_animation_to_sequence.py
+++ b/client/ayon_unreal/plugins/inventory/connect_animation_to_sequence.py
@@ -95,9 +95,17 @@ class ConnectFbxAnimation(InventoryAction):
         namespace = next((
             container.get("namespace") for container in containers
             if container.get("family") == "camera"), None)
+        start_frame, end_frame = get_frame_range_from_folder_attributes()
+        frameStart = next((
+            int(container.get("clipIn", start_frame)) for container in containers
+            if container.get("family") == "camera"), None)
+        frameEnd = next((
+            int(container.get("clipOut", end_frame)) for container in containers
+            if container.get("family") == "camera"), None)
         layout_world = self.get_layout_asset(containers, asset_name="World")
         import_camera_to_level_sequence(
-            sequence, parent_id, version_id, namespace, layout_world)
+            sequence, parent_id, version_id, namespace, layout_world,
+            frameStart, frameEnd)
 
     def import_animation_sequence(self, asset_content, sequence, frameStart, frameEnd):
         import_animation_sequence(asset_content, sequence, frameStart, frameEnd)

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -64,7 +64,9 @@ class CameraLoader(plugin.Loader):
         asset_name,
         representation,
         folder_name,
-        product_type):
+        product_type,
+        clipIn,
+        clipOut):
         data = {
             "schema": "ayon:container-2.0",
             "id": AYON_CONTAINER_ID,
@@ -79,6 +81,8 @@ class CameraLoader(plugin.Loader):
             # TODO these should be probably removed
             "asset": folder_name,
             "family": product_type,
+            "clipIn": clipIn,
+            "clipOut": clipOut
         }
         imprint(f"{asset_dir}/{container_name}", data)
 
@@ -271,7 +275,9 @@ class CameraLoader(plugin.Loader):
             asset_name,
             context["representation"],
             folder_name,
-            context["product"]["productType"]
+            context["product"]["productType"],
+            folder_entity["attrib"]["clipIn"],
+            folder_entity["attrib"]["clipOut"] + 1
         )
 
         EditorLevelLibrary.save_all_dirty_levels()
@@ -341,7 +347,9 @@ class CameraLoader(plugin.Loader):
             asset_name,
             context["representation"],
             folder_name,
-            context["product"]["productType"]
+            context["product"]["productType"],
+            folder_entity["attrib"]["clipIn"],
+            folder_entity["attrib"]["clipOut"] + 1
         )
 
         EditorLevelLibrary.save_all_dirty_levels()


### PR DESCRIPTION
## Changelog Description
This PR is to resolve the issue of camera appearing not to be bind into the camera cut. It is not "bind" due to the improper setup on the playback frame range. 
Resolve https://github.com/ynput/ayon-unreal/issues/123


## Additional info
Need to reload/not load the new camera for this PR for testing if the frame range data is collected

## Testing notes:

1.  Launch Unreal
2.  Go to the UE level which is created by the layout
3.  Ayon -> Manage
4.  Select Layout and Camera Instances
5. Right-Click -> Actions -> Connect Fbx/Alembic Animation to Level Sequence.