### PR TITLE
Spawned actors loaded from layout existing should be added into level sequence for the layout

### DIFF
--- a/client/ayon_unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_unreal/plugins/load/load_layout_existing.py
@@ -75,7 +75,7 @@ class ExistingLayoutLoader(plugin.Loader):
 
         return new_transform.transform()
 
-    def _spawn_actor(self, obj, lasset):
+    def _spawn_actor(self, obj, lasset, sequence):
         actor = EditorLevelLibrary.spawn_actor_from_object(
             obj, unreal.Vector(0.0, 0.0, 0.0)
         )
@@ -92,6 +92,7 @@ class ExistingLayoutLoader(plugin.Loader):
                 roll=rotation["x"], pitch=rotation["z"],
                 yaw=-rotation["y"])
             actor.set_actor_rotation(actor_rotation, False)
+        sequence.add_possessable(actor)
 
     @staticmethod
     def _get_fbx_loader(loaders, family):
@@ -216,7 +217,7 @@ class ExistingLayoutLoader(plugin.Loader):
             output[version_id].append(repre_entity)
         return output
 
-    def _process(self, lib_path, project_name):
+    def _process(self, lib_path, project_name, sequence):
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
 
         actors = EditorLevelLibrary.get_all_level_actors()
@@ -347,7 +348,7 @@ class ExistingLayoutLoader(plugin.Loader):
 
                 for asset in assets:
                     obj = asset.get_asset()
-                    self._spawn_actor(obj, lasset)
+                    self._spawn_actor(obj, lasset, sequence)
                 loaded = True
                 break
 
@@ -379,7 +380,7 @@ class ExistingLayoutLoader(plugin.Loader):
                 if not obj.get_class().get_name() == 'StaticMesh':
                     continue
 
-                self._spawn_actor(obj, lasset)
+                self._spawn_actor(obj, lasset, sequence)
                 if obj.get_class().get_name() == 'AyonAssetContainer':
                     con = obj
                     containers.append(con.get_path_name())
@@ -404,7 +405,7 @@ class ExistingLayoutLoader(plugin.Loader):
         folder_path = folder_entity["path"]
         hierarchy = folder_path.lstrip("/").split("/")
         # Remove folder name
-        folder_name = hierarchy.pop(-1)
+        folder_name = hierarchy.pop(-1) if len(hierarchy) > 0 else hierarchy
         product_type = context["product"]["productType"]
         root = self.ASSET_ROOT
         hierarchy_dir = root
@@ -422,13 +423,19 @@ class ExistingLayoutLoader(plugin.Loader):
             suffix="_existing"
         )
         curr_level = self._get_current_level()
+        level_seq_filter = unreal.ARFilter(
+            class_names=["LevelSequence"],
+            package_paths=[asset_dir],
+            recursive_paths=False)
 
+        ar = unreal.AssetRegistryHelpers.get_asset_registry()
+        sequence = next((asset for asset in ar.get_assets(level_seq_filter)), None)
         if not curr_level:
             raise AssertionError("Current level not saved")
 
         project_name = context["project"]["name"]
         path = self.filepath_from_context(context)
-        containers = self._process(path, project_name)
+        containers = self._process(path, project_name, sequence)
         curr_level_path = Path(
             curr_level.get_outer().get_path_name()).parent.as_posix()
         if curr_level_path == "/Temp":
@@ -465,9 +472,15 @@ class ExistingLayoutLoader(plugin.Loader):
 
         project_name = context["project"]["name"]
         repre_entity = context["representation"]
+        level_seq_filter = unreal.ARFilter(
+            class_names=["LevelSequence"],
+            package_paths=[asset_dir],
+            recursive_paths=False)
 
+        ar = unreal.AssetRegistryHelpers.get_asset_registry()
+        sequence = next((asset for asset in ar.get_assets(level_seq_filter)), None)
         source_path = get_representation_path(repre_entity)
-        containers = self._process(source_path, project_name)
+        containers = self._process(source_path, project_name, sequence)
 
         data = {
             "representation": repre_entity["id"],

--- a/client/ayon_unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_unreal/plugins/load/load_layout_existing.py
@@ -422,26 +422,27 @@ class ExistingLayoutLoader(plugin.Loader):
             "{}/{}/{}".format(hierarchy_dir, folder_name, name),
             suffix="_existing"
         )
+
         curr_level = self._get_current_level()
-        level_seq_filter = unreal.ARFilter(
-            class_names=["LevelSequence"],
-            package_paths=[asset_dir],
-            recursive_paths=False)
-
-        ar = unreal.AssetRegistryHelpers.get_asset_registry()
-        sequence = next((asset for asset in ar.get_assets(level_seq_filter)), None)
-        if not curr_level:
-            raise AssertionError("Current level not saved")
-
-        project_name = context["project"]["name"]
-        path = self.filepath_from_context(context)
-        containers = self._process(path, project_name, sequence)
         curr_level_path = Path(
             curr_level.get_outer().get_path_name()).parent.as_posix()
         if curr_level_path == "/Temp":
             curr_level_path = asset_dir
         #TODO: make sure curr_level_path is not a temp path,
         # create new level for layout level
+        level_seq_filter = unreal.ARFilter(
+            class_names=["LevelSequence"],
+            package_paths=[curr_level_path],
+            recursive_paths=False)
+
+        ar = unreal.AssetRegistryHelpers.get_asset_registry()
+        sequence = next((asset.get_asset() for asset in ar.get_assets(level_seq_filter)), None)
+        if not curr_level:
+            raise AssertionError("Current level not saved")
+
+        project_name = context["project"]["name"]
+        path = self.filepath_from_context(context)
+        containers = self._process(path, project_name, sequence)
         container_name += suffix
         if not unreal.EditorAssetLibrary.does_asset_exist(
             f"{curr_level_path}/{container_name}"


### PR DESCRIPTION
## Changelog Description
This PR is to make sure all spawned actors which are loaded from layout existing loader should be added as binding object into level seqenece  for the layout product type
Resolve https://github.com/ynput/ayon-unreal/issues/121

## Additional info
n/a


## Testing notes:

1. Launch Unreal
2. Load Layout
3. Save
4. Check on the level sequence
5. Load Layout Existing
6. Check on the level sequence again, the assets loaded from the layout existing loader are added into that. 