### PR TITLE
Make sure the frame range of camera cut/animation sequence are correct when using connect action

### DIFF
--- a/client/ayon_unreal/api/lib.py
+++ b/client/ayon_unreal/api/lib.py
@@ -88,7 +88,7 @@ def import_animation_sequence(asset_content, sequence, frameStart, frameEnd):
             params = unreal.MovieSceneSkeletalAnimationParams()
             params.set_editor_property('Animation', animation)
             anim_section.set_editor_property('Params', params)
-            anim_section.set_range(frameStart, frameEnd)
+            anim_section.set_range(frameStart + 1, frameEnd + 2)
 
 
 def get_representation(parent_id, version_id):
@@ -134,6 +134,6 @@ def import_camera_to_level_sequence(sequence, parent_id, version_id,
     for track in tracks:
         sections = track.get_sections()
         for section in sections:
-            section.set_range(frameStart, frameEnd)
+            section.set_range(frameStart + 1, frameEnd + 2)
 
     set_sequence_frame_range(sequence, frameStart, frameEnd)

--- a/client/ayon_unreal/api/lib.py
+++ b/client/ayon_unreal/api/lib.py
@@ -48,8 +48,8 @@ def set_sequence_frame_range(sequence, frameStart, frameEnd):
     display_rate = sequence.get_display_rate()
     fps = float(display_rate.numerator) / float(display_rate.denominator)
     # temp fix on the incorrect frame range
-    sequence.set_playback_start(frameStart + 1)
-    sequence.set_playback_end(frameEnd + 2)
+    sequence.set_playback_start(frameStart)
+    sequence.set_playback_end(frameEnd + 1)
     sequence.set_work_range_start(float(frameStart / fps))
     sequence.set_work_range_end(float(frameEnd / fps))
     sequence.set_view_range_start(float(frameStart / fps))
@@ -90,7 +90,7 @@ def import_animation_sequence(asset_content, sequence, frameStart, frameEnd):
             params.set_editor_property('Animation', animation)
             anim_section.set_editor_property('Params', params)
             # temp fix on the incorrect frame range
-            anim_section.set_range(frameStart + 1, frameEnd + 2)
+            anim_section.set_range(frameStart, frameEnd + 1)
 
 
 def get_representation(parent_id, version_id):
@@ -137,6 +137,6 @@ def import_camera_to_level_sequence(sequence, parent_id, version_id,
         sections = track.get_sections()
         for section in sections:
             # temp fix on the incorrect frame range
-            section.set_range(frameStart + 1, frameEnd + 2)
+            section.set_range(frameStart, frameEnd + 1)
 
     set_sequence_frame_range(sequence, frameStart, frameEnd)

--- a/client/ayon_unreal/api/lib.py
+++ b/client/ayon_unreal/api/lib.py
@@ -47,8 +47,9 @@ def update_skeletal_mesh(asset_content, sequence):
 def set_sequence_frame_range(sequence, frameStart, frameEnd):
     display_rate = sequence.get_display_rate()
     fps = float(display_rate.numerator) / float(display_rate.denominator)
-    sequence.set_playback_start(frameStart)
-    sequence.set_playback_end(frameEnd)
+    # temp fix on the incorrect frame range
+    sequence.set_playback_start(frameStart + 1)
+    sequence.set_playback_end(frameEnd + 2)
     sequence.set_work_range_start(float(frameStart / fps))
     sequence.set_work_range_end(float(frameEnd / fps))
     sequence.set_view_range_start(float(frameStart / fps))
@@ -88,6 +89,7 @@ def import_animation_sequence(asset_content, sequence, frameStart, frameEnd):
             params = unreal.MovieSceneSkeletalAnimationParams()
             params.set_editor_property('Animation', animation)
             anim_section.set_editor_property('Params', params)
+            # temp fix on the incorrect frame range
             anim_section.set_range(frameStart + 1, frameEnd + 2)
 
 
@@ -134,6 +136,7 @@ def import_camera_to_level_sequence(sequence, parent_id, version_id,
     for track in tracks:
         sections = track.get_sections()
         for section in sections:
+            # temp fix on the incorrect frame range
             section.set_range(frameStart + 1, frameEnd + 2)
 
     set_sequence_frame_range(sequence, frameStart, frameEnd)


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-unreal/issues/144
This PR is to make sure the correct frame range of camera cut or animation sequence when they are imported by using connect action in scene inventory.


## Additional info
This is a temporary fix only and it would be restored to use the actual frame range once Epic has fixed the incorrect frame range when the asset has been imported.


## Testing notes:

1. Launch Unreal
2. Load Layout/Camera/Animation
3. Use connect action by selecting layout/camera/animation containers
