### PR TITLE
Backward compatibility for json layout without extension as data

### DIFF
--- a/client/ayon_unreal/api/plugin.py
+++ b/client/ayon_unreal/api/plugin.py
@@ -375,7 +375,7 @@ class LayoutLoader(Loader):
             return output
         # Extract extensions from data with backward compatibility for "ma"
         extensions = {
-            element["extension"]
+            element.get("extension", "ma")
             for element in data
             if element.get("representation")
         }

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -167,7 +167,7 @@ class LayoutLoader(plugin.LayoutLoader):
                         f"No valid representation found for version"
                         f" {version_id}")
                     continue
-                extension = element.get("extension")
+                extension = element.get("extension", "ma")
                 repre_entity = None
                 if not force_loaded or loaded_extension == "json":
                     repre_entity = next((repre_entity for repre_entity in repre_entities

--- a/client/ayon_unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_unreal/plugins/load/load_layout_existing.py
@@ -86,7 +86,7 @@ class ExistingLayoutLoader(plugin.LayoutLoader):
         # Get all the representations in the JSON from the database.
         for element in data:
             repre_id = element.get('representation')
-            extension = element.get("extension")
+            extension = element.get("extension", "ma")
             if repre_id:
                 repre_ids.add(repre_id)
                 elements.append(element)


### PR DESCRIPTION
## Changelog Description
This PR is to add backward compatibility for json layout to avoid the error from the missing data of "extension" in the old published layout.

## Additional review information
n/a.

## Testing notes:
1. Launch Unreal
2. Load Layout with both old/new published layout
3. Should be working