### PR TITLE
Implement function to get tracks for different UE version

### DIFF
--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -1225,6 +1225,6 @@ def add_track(sequence, track):
         UNREAL_VERSION.major == 5
         and UNREAL_VERSION.minor > 4
     ):
-        return sequence.add_tracks(track)
+        return sequence.add_track(track)
     else:
         return sequence.add_master_track(track)

--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -540,10 +540,10 @@ def set_sequence_hierarchy(
                 unreal.MovieSceneLevelVisibilityTrack.static_class()):
             visibility_track = t
     if not subscene_track:
-        subscene_track = seq_i.add_master_track(unreal.MovieSceneSubTrack)
+        subscene_track = add_track(seq_i, unreal.MovieSceneSubTrack)
     if not visibility_track:
-        visibility_track = seq_i.add_master_track(
-            unreal.MovieSceneLevelVisibilityTrack)
+        visibility_track = add_track(
+            seq_i, unreal.MovieSceneLevelVisibilityTrack)
 
     # Create the sub-scene section
     subscenes = subscene_track.get_sections()
@@ -651,8 +651,7 @@ def generate_sequence(h, h_dir):
             track = t
             break
     if not track:
-        track = sequence.add_master_track(
-            unreal.MovieSceneCameraCutTrack)
+        track = add_track(sequence, unreal.MovieSceneCameraCutTrack)
 
     return sequence, (min_frame, max_frame)
 
@@ -1211,3 +1210,21 @@ def get_tracks(sequence):
         return sequence.get_tracks()
     else:
         return sequence.get_master_tracks()
+
+
+def add_track(sequence, track):
+    """Backward compatibility for deprecated function of add_master_track() in UE 5.5
+
+    Args:
+        sequence (unreal.LevelSequence): Level Sequence
+
+    Returns:
+        MovieSceneTrack: Any tracks inherited from unreal.MovieSceneTrack
+    """
+    if (
+        UNREAL_VERSION.major == 5
+        and UNREAL_VERSION.minor > 4
+    ):
+        return sequence.add_tracks(track)
+    else:
+        return sequence.add_master_track(track)

--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -512,7 +512,7 @@ def get_subsequences(sequence: unreal.LevelSequence):
         list(unreal.LevelSequence): List of subsequences
 
     """
-    tracks = sequence.get_master_tracks()
+    tracks = get_tracks(sequence)
     subscene_track = next(
         (
             t
@@ -530,7 +530,7 @@ def set_sequence_hierarchy(
     seq_i, seq_j, max_frame_i, min_frame_j, max_frame_j, map_paths
 ):
     # Get existing sequencer tracks or create them if they don't exist
-    tracks = seq_i.get_master_tracks()
+    tracks = get_tracks(seq_i)
     subscene_track = None
     visibility_track = None
     for t in tracks:
@@ -643,7 +643,7 @@ def generate_sequence(h, h_dir):
     sequence.set_view_range_start(min_frame / fps)
     sequence.set_view_range_end(max_frame / fps)
 
-    tracks = sequence.get_master_tracks()
+    tracks = get_tracks(sequence)
     track = None
     for t in tracks:
         if (t.get_class() ==
@@ -985,7 +985,7 @@ def get_camera_tracks(sequence):
         list: list of movie scene camera cut tracks
     """
     camera_tracks = []
-    tracks = sequence.get_master_tracks()
+    tracks = get_tracks(sequence)
     for track in tracks:
         if str(track).count("MovieSceneCameraCutTrack"):
             camera_tracks.append(track)
@@ -1193,3 +1193,21 @@ def generate_master_level_sequence(tools, asset_dir, asset_name,
             [asset_level])
 
     return shot, master_level, asset_level, sequences, frame_ranges
+
+
+def get_tracks(sequence):
+    """Backward compatibility for deprecated function of get_master_tracks() in UE 5.5
+
+    Args:
+        sequence (unreal.LevelSequence): Level Sequence
+
+    Returns:
+        Array(MovieSceneTracks): Movie scene tracks
+    """
+    if (
+        UNREAL_VERSION.major == 5
+        and UNREAL_VERSION.minor > 4
+    ):
+        return sequence.get_tracks()
+    else:
+        return sequence.get_master_tracks()

--- a/client/ayon_unreal/plugins/load/load_image_png.py
+++ b/client/ayon_unreal/plugins/load/load_image_png.py
@@ -87,11 +87,9 @@ class TexturePNGLoader(plugin.Loader):
 
             # The path to the Interchange asset
             tmp_pipeline_path = "/Game/tmp"
-            pipeline = editor_asset_subsystem.duplicate_asset(
-                self.pipeline_path, tmp_pipeline_path)
-
+            # interchange settings here
             unreal.EditorAssetLibrary.rename_asset(
-                pipeline.get_path_name(),
+                f"{self.pipeline_path}",
                 f"{tmp_pipeline_path}/{asset_name}.{asset_name}"
             )
 

--- a/client/ayon_unreal/plugins/load/load_image_png.py
+++ b/client/ayon_unreal/plugins/load/load_image_png.py
@@ -90,8 +90,10 @@ class TexturePNGLoader(plugin.Loader):
             pipeline = editor_asset_subsystem.duplicate_asset(
                 self.pipeline_path, tmp_pipeline_path)
 
-            # Interchange settings here
-            pipeline.asset_name = asset_name
+            unreal.EditorAssetLibrary.rename_asset(
+                pipeline.get_path_name(),
+                f"{tmp_pipeline_path}/{asset_name}.{asset_name}"
+            )
 
             import_assetparameters.override_pipelines.append(
                 unreal.SoftObjectPath(f"{tmp_pipeline_path}.tmp"))

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -12,8 +12,7 @@ import ayon_api
 
 from ayon_core.pipeline import (
     get_representation_path,
-    get_current_project_name,
-    get_tracks
+    get_current_project_name
 )
 from ayon_core.settings import get_current_project_settings
 from ayon_unreal.api import plugin
@@ -26,7 +25,8 @@ from ayon_unreal.api.pipeline import (
     get_top_hierarchy_folder,
     generate_hierarchy_path,
     update_container,
-    remove_map_and_sequence
+    remove_map_and_sequence,
+    get_tracks
 )
 from ayon_unreal.api.lib import (
     import_animation

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -13,6 +13,7 @@ import ayon_api
 from ayon_core.pipeline import (
     get_representation_path,
     get_current_project_name,
+    get_tracks
 )
 from ayon_core.settings import get_current_project_settings
 from ayon_unreal.api import plugin
@@ -485,7 +486,7 @@ class LayoutLoader(plugin.LayoutLoader):
 
             parent = None
             for s in sequences:
-                tracks = s.get_master_tracks()
+                tracks = get_tracks(s)
                 subscene_track = None
                 visibility_track = None
                 for t in tracks:

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -211,8 +211,8 @@ class LayoutLoader(plugin.LayoutLoader):
                         container = obj
                     if obj.get_class().get_name() == 'Skeleton':
                         skeleton = obj
-
-                loaded_assets.append(container.get_path_name())
+                    if container is not None:
+                        loaded_assets.append(container.get_path_name())
 
                 instances = [
                     item for item in data
@@ -341,7 +341,8 @@ class LayoutLoader(plugin.LayoutLoader):
             path, project_name, asset_dir, shot,
             loaded_extension=extension,
             force_loaded=self.force_loaded)
-
+        unreal.log("loaded assets")
+        unreal.log(loaded_assets)
         for s in sequences:
             EditorAssetLibrary.save_asset(s.get_path_name())
 

--- a/client/ayon_unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_unreal/plugins/load/load_layout_existing.py
@@ -58,7 +58,13 @@ class ExistingLayoutLoader(plugin.LayoutLoader):
                 roll=rotation["x"], pitch=rotation["z"],
                 yaw=-rotation["y"])
             actor.set_actor_rotation(actor_rotation, False)
-        sequence.add_possessable(actor)
+        if sequence is not None:
+            sequence.add_possessable(actor)
+        else:
+            self.log.warning(
+                "No Level Sequence found for current level. "
+                "Skipping to add spawned actor into the sequence."
+            )
 
     def _load_asset(self, repr_data, instance_name, family, extension):
         repre_entity = next((repre_entity for repre_entity in repr_data
@@ -290,8 +296,6 @@ class ExistingLayoutLoader(plugin.LayoutLoader):
 
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
         sequence = next((asset.get_asset() for asset in ar.get_assets(level_seq_filter)), None)
-        if not sequence:
-            raise LoadError("No Level Sequence found for current level")
         if not curr_level:
             raise LoadError("Current level not saved")
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -91,8 +91,6 @@ class StaticMeshFBXLoader(plugin.Loader):
             # The path to the Interchange asset
             tmp_pipeline_path = "/Game/tmp"
             # interchange settings here
-            # pipeline = editor_asset_subsystem.duplicate_asset(
-            #     cls.pipeline_path, tmp_pipeline_path)
             unreal.EditorAssetLibrary.rename_asset(
                 f"{cls.pipeline_path}",
                 f"{tmp_pipeline_path}/{asset_name}.{asset_name}"

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -91,11 +91,10 @@ class StaticMeshFBXLoader(plugin.Loader):
             # The path to the Interchange asset
             tmp_pipeline_path = "/Game/tmp"
             # interchange settings here
-            pipeline = editor_asset_subsystem.duplicate_asset(
-                cls.pipeline_path, tmp_pipeline_path)
-
+            # pipeline = editor_asset_subsystem.duplicate_asset(
+            #     cls.pipeline_path, tmp_pipeline_path)
             unreal.EditorAssetLibrary.rename_asset(
-                pipeline.get_path_name(),
+                f"{cls.pipeline_path}",
                 f"{tmp_pipeline_path}/{asset_name}.{asset_name}"
             )
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -88,11 +88,16 @@ class StaticMeshFBXLoader(plugin.Loader):
             editor_asset_subsystem = unreal.EditorAssetSubsystem()
             import_assetparameters.is_automated = not cls.show_dialog
 
+            # The path to the Interchange asset
             tmp_pipeline_path = "/Game/tmp"
-            pipeline = editor_asset_subsystem.duplicate_asset(cls.pipeline_path, tmp_pipeline_path) # the path to the Interchange asset
-
             # interchange settings here
-            pipeline.asset_name = asset_name
+            pipeline = editor_asset_subsystem.duplicate_asset(
+                cls.pipeline_path, tmp_pipeline_path)
+
+            unreal.EditorAssetLibrary.rename_asset(
+                pipeline.get_path_name(),
+                f"{tmp_pipeline_path}/{asset_name}.{asset_name}"
+            )
 
             import_assetparameters.override_pipelines.append(
                 unreal.SoftObjectPath(f"{tmp_pipeline_path}.tmp"))
@@ -106,7 +111,7 @@ class StaticMeshFBXLoader(plugin.Loader):
             editor_asset_subsystem.delete_asset(tmp_pipeline_path) # remove temp file
 
         else:
-            unreal.log("Import using defered method")
+            unreal.log("Import using deferred method")
             task = None
             if asset_path:
                 loaded_asset_dir = unreal.Paths.split(asset_path)[0]

--- a/client/ayon_unreal/plugins/publish/extract_camera.py
+++ b/client/ayon_unreal/plugins/publish/extract_camera.py
@@ -7,7 +7,8 @@ import unreal
 from ayon_core.pipeline import publish
 from ayon_unreal.api.pipeline import (
     UNREAL_VERSION,
-    select_camera
+    select_camera,
+    get_tracks
 )
 
 
@@ -64,7 +65,7 @@ class ExtractCamera(publish.Extractor):
                                 root_sequence=sequence,
                                 sequence=sequence,
                                 bindings=sequence.get_bindings(),
-                                master_tracks=sequence.get_master_tracks(),
+                                master_tracks=get_tracks(sequence),
                                 fbx_file_name=os.path.join(staging_dir, fbx_filename)
                             )
                         unreal.SequencerTools.export_level_sequence_fbx(params)

--- a/client/ayon_unreal/plugins/publish/validate_camera_tracks.py
+++ b/client/ayon_unreal/plugins/publish/validate_camera_tracks.py
@@ -3,7 +3,7 @@
 import pyblish.api
 import unreal
 from ayon_core.pipeline.publish import PublishValidationError, RepairAction
-from ayon_unreal.api.pipeline import get_tracks
+from ayon_unreal.api.lib import get_tracks, add_track
 
 
 class ValidateCameraTracks(pyblish.api.InstancePlugin):
@@ -72,4 +72,4 @@ class ValidateCameraTracks(pyblish.api.InstancePlugin):
                 data.asset_class_path.asset_name == "LevelSequence")
             if is_level_sequence:
                 sequence = data.get_asset()
-                sequence.add_master_track(unreal.MovieSceneCameraCutTrack)
+                add_track(sequence, unreal.MovieSceneCameraCutTrack)

--- a/client/ayon_unreal/plugins/publish/validate_camera_tracks.py
+++ b/client/ayon_unreal/plugins/publish/validate_camera_tracks.py
@@ -3,6 +3,7 @@
 import pyblish.api
 import unreal
 from ayon_core.pipeline.publish import PublishValidationError, RepairAction
+from ayon_unreal.api.pipeline import get_tracks
 
 
 class ValidateCameraTracks(pyblish.api.InstancePlugin):
@@ -33,7 +34,7 @@ class ValidateCameraTracks(pyblish.api.InstancePlugin):
                     "The published assets must be Level Sequence")
             sequence = data.get_asset()
             seq_name = sequence.get_name()
-            all_tracks = sequence.get_master_tracks()
+            all_tracks = get_tracks(sequence)
             if not all_tracks:
                 message = (
                     f"No tracks found in Level Sequence {seq_name}. You can perform\n "


### PR DESCRIPTION
## Changelog Description
Implement the backward compatibility function for `get_master_tracks` so that the Ayon plugins can be used across different UE versions regarding to the update of 5.5
Resolve https://github.com/ynput/ayon-unreal/issues/162

## Additional review information
n/a

## Testing notes:
1. Test Unreal with this branch (Like loading, publishing etc.)
