### PR TITLE
Add support for more output path format strings on farm render

### DIFF
--- a/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
@@ -146,7 +146,7 @@ class CreateFarmRenderInstances(publish.AbstractCollectRender):
             if family not in ["render"]:
                 continue
 
-            # skip if locar render instances
+            # skip if local render instances
             if "render.local" in instance_families:
                 continue
 

--- a/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
@@ -288,8 +288,8 @@ class CreateFarmRenderInstances(publish.AbstractCollectRender):
         sequence_path = job.sequence.export_text()
         map_path = job.map.export_text()
 
-        sequence_name = os.path.splitext(os.path.basename(sequence_path)[0])
-        map_name = os.path.splitext(os.path.basename(map_path)[0])
+        sequence_name = os.path.splitext(os.path.basename(sequence_path))[0]
+        map_name = os.path.splitext(os.path.basename(map_path))[0]
 
         file_name_format = file_name_format.replace("{sequence_name}", sequence_name)
         file_name_format = file_name_format.replace("{level_name}", map_name)


### PR DESCRIPTION
## Changelog Description
Added support for `level_name`, `job_name` and `version` format strings in the output file name for farm render instances. 

## Additional review information
The `version` field is acquired from the render config if auto versioning is disabled. Otherwise, it will use the pre-existing version parameter.

## Testing notes:
1. Save a Movie Pipeline Config with format strings in the filename.
2. Save a Render Queue with one or more shots.
3. Submit the jobs as a Farm render.