### PR TITLE
Implement backward compatibility of some template keys for asset directory mapping

### DIFF
--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -859,7 +859,26 @@ def format_asset_directory(context, directory_template):
     """
 
     data = copy.deepcopy(context)
+    if "{product[type]}" in directory_template:
+        unreal.warning(
+            "{{product[type]}} is deprecated, "
+            "using {{product[productType]}} "
+            "from context data for directory mapping"
+        )
+        directory_template = directory_template.replace(
+            "{product[type]}", "{product[productType]}")
+
+    if "{folder[type]}" in directory_template:
+        unreal.warning(
+            "{{folder[type]}} is deprecated, "
+            "using {{folder[folderType]}} "
+            "from context data for directory mapping"
+        )
+        directory_template = directory_template.replace(
+            "{folder[type]}", "{folder[folderType]}")
+
     version = data["version"]["version"]
+
     # if user set {version[version]},
     # the copied data from data["version"]["version"] convert
     # to set the version of the exclusive version folder


### PR DESCRIPTION
## Changelog Description
This PR is to add backward compatibility of the template keys such as `{product[type]}` and `{folder[type]}`  for asset directory mapping. If the keys are detected, the system would be using their replacements for mapping the directories.
Resolve https://github.com/ynput/ayon-unreal/issues/156

## Additional review information
n/a

## Testing notes:
1. Launch Unreal
2. Set some old template keys in `ayon+settings://unreal/loaded_asset_dir` or `ayon+settings://unreal/loaded_layout_dir`
![image](https://github.com/user-attachments/assets/be3eb507-3752-4f52-96d5-7d41a7d8772b)
3. Load Assets
