### PR TITLE
Emit action for building unreal workfile project preparation

### DIFF
--- a/client/ayon_unreal/ue_workers.py
+++ b/client/ayon_unreal/ue_workers.py
@@ -260,6 +260,9 @@ class UEProjectGenerationWorker(UEWorker):
                 self.failed.emit(msg, return_code)
                 raise RuntimeError(msg)
 
+        self.progress.emit(100)
+        self.finished.emit("Project successfully built!")
+
 
 class UEPluginInstallWorker(UEWorker):
     installing = QtCore.Signal(str)


### PR DESCRIPTION
## Changelog Description
This PR is to fix the issue of getting struck at the indefinite loop of pre-workfile preparation(aka Project building) in Unreal when the users firstly launch Unreal with the new task.

## Additional review information
n/a

## Testing notes:
1. Launch Unreal with the new Task
2. Project should be built successfully and the Ayon plugins should be working
