### PR TITLE
Backport load transform to older UE versions

### DIFF
--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -67,7 +67,7 @@ class AnimationAlembicLoader(plugin.Loader):
                     preset=unreal.AbcConversionPreset.CUSTOM,
                     flip_u=False, flip_v=True,
                     rotation=[90.0, 0.0, 0.0],
-                    scale=[100.0, -100.0, 100.0])
+                    scale=[1.0, -1.0, 1.0])
         elif abc_conversion_preset == "3dsmax":
             if unreal_pipeline.UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -58,15 +58,16 @@ class AnimationAlembicLoader(plugin.Loader):
         conversion_settings = unreal.AbcConversionSettings()
         abc_conversion_preset = loaded_options.get("abc_conversion_preset")
         if abc_conversion_preset == "maya":
-            if unreal_pipeline.UNREAL_VERSION.major >= 5:
+            if unreal_pipeline.UNREAL_VERSION.major >= 5 and (
+                unreal_pipeline.UNREAL_VERSION.minor >= 2):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset= unreal.AbcConversionPreset.MAYA)
             else:
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.CUSTOM,
                     flip_u=False, flip_v=True,
-                    rotation=[90.0, 0.0, 0.0],
-                    scale=[1.0, -1.0, 1.0])
+                    rotation=[-90.0, 0.0, 180.0],
+                    scale=[100.0, 100.0, 100.0])
         elif abc_conversion_preset == "3dsmax":
             if unreal_pipeline.UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -59,7 +59,7 @@ class AnimationAlembicLoader(plugin.Loader):
         abc_conversion_preset = loaded_options.get("abc_conversion_preset")
         if abc_conversion_preset == "maya":
             if unreal_pipeline.UNREAL_VERSION.major >= 5 and (
-                unreal_pipeline.UNREAL_VERSION.minor >= 2):
+                unreal_pipeline.UNREAL_VERSION.minor >= 3):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset= unreal.AbcConversionPreset.MAYA)
             else:

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -59,7 +59,7 @@ class AnimationAlembicLoader(plugin.Loader):
         abc_conversion_preset = loaded_options.get("abc_conversion_preset")
         if abc_conversion_preset == "maya":
             if unreal_pipeline.UNREAL_VERSION.major >= 5 and (
-                unreal_pipeline.UNREAL_VERSION.minor >= 3):
+                unreal_pipeline.UNREAL_VERSION.minor >= 4):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset= unreal.AbcConversionPreset.MAYA)
             else:

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -66,8 +66,8 @@ class AnimationAlembicLoader(plugin.Loader):
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.CUSTOM,
                     flip_u=False, flip_v=True,
-                    rotation=[-90.0, 0.0, 180.0],
-                    scale=[100.0, 100.0, 100.0])
+                    rotation=[90.0, 0.0, 0.0],
+                    scale=[100.0, -100.0, 100.0])
         elif abc_conversion_preset == "3dsmax":
             if unreal_pipeline.UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -9,6 +9,7 @@ from ayon_core.pipeline import (
 )
 from ayon_unreal.api import plugin
 from ayon_unreal.api import pipeline as unreal_pipeline
+from ayon_core.settings import get_current_project_settings
 import unreal  # noqa
 
 
@@ -43,7 +44,8 @@ class AnimationAlembicLoader(plugin.Loader):
                 label="Alembic Conversion Preset",
                 items={
                     "3dsmax": "3dsmax",
-                    "maya": "maya"
+                    "maya": "maya",
+                    "custom": "custom"
                 },
                 default=cls.abc_conversion_preset
             )
@@ -56,8 +58,7 @@ class AnimationAlembicLoader(plugin.Loader):
         conversion_settings = unreal.AbcConversionSettings()
         abc_conversion_preset = loaded_options.get("abc_conversion_preset")
         if abc_conversion_preset == "maya":
-            if unreal_pipeline.UNREAL_VERSION.major >= 5 and (
-                unreal_pipeline.UNREAL_VERSION.minor >= 4):
+            if unreal_pipeline.UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset= unreal.AbcConversionPreset.MAYA)
             else:
@@ -67,8 +68,7 @@ class AnimationAlembicLoader(plugin.Loader):
                     rotation=[90.0, 0.0, 0.0],
                     scale=[1.0, -1.0, 1.0])
         elif abc_conversion_preset == "3dsmax":
-            if unreal_pipeline.UNREAL_VERSION.major >= 5 and (
-                unreal_pipeline.UNREAL_VERSION.minor >= 4):
+            if unreal_pipeline.UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAX)
             else:
@@ -77,6 +77,26 @@ class AnimationAlembicLoader(plugin.Loader):
                     flip_u=False, flip_v=True,
                     rotation=[0.0, 0.0, 0.0],
                     scale=[1.0, -1.0, 1.0])
+        else:
+            data = get_current_project_settings()
+            preset = (
+                data["unreal"]["import_settings"]["custom"]
+            )
+            conversion_settings = unreal.AbcConversionSettings(
+                preset=unreal.AbcConversionPreset.CUSTOM,
+                flip_u=preset["flip_u"],
+                flip_v=preset["flip_v"],
+                rotation=[
+                    preset["rot_x"],
+                    preset["rot_y"],
+                    preset["rot_z"]
+                ],
+                scale=[
+                    preset["scl_x"],
+                    preset["scl_y"],
+                    preset["scl_z"]
+                ]
+            )
 
         options.sampling_settings.frame_start = loaded_options.get("frameStart")
         options.sampling_settings.frame_end = loaded_options.get("frameEnd")

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -69,15 +69,15 @@ class PointCacheAlembicLoader(plugin.Loader):
         sampling_settings = unreal.AbcSamplingSettings()
         abc_conversion_preset = loaded_options.get("abc_conversion_preset")
         if abc_conversion_preset == "maya":
-            if UNREAL_VERSION.major >= 5:
+            if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 2:
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.MAYA)
             else:
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.CUSTOM,
                     flip_u=False, flip_v=True,
-                    rotation=[90.0, 0.0, 0.0],
-                    scale=[1.0, -1.0, 1.0])
+                    rotation=[-90.0, 0.0, 180.0],
+                    scale=[100.0, 100.0, 100.0])
         elif abc_conversion_preset == "3dsmax":
             if UNREAL_VERSION.major >= 5:
                 conversion_settings = unreal.AbcConversionSettings(

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -69,7 +69,7 @@ class PointCacheAlembicLoader(plugin.Loader):
         sampling_settings = unreal.AbcSamplingSettings()
         abc_conversion_preset = loaded_options.get("abc_conversion_preset")
         if abc_conversion_preset == "maya":
-            if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 3:
+            if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 4:
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.MAYA)
             else:

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -15,6 +15,7 @@ from ayon_unreal.api.pipeline import (
     format_asset_directory,
     UNREAL_VERSION
 )
+from ayon_core.settings import get_current_project_settings
 
 import unreal  # noqa
 
@@ -49,7 +50,8 @@ class PointCacheAlembicLoader(plugin.Loader):
                 label="Alembic Conversion Preset",
                 items={
                     "3dsmax": "3dsmax",
-                    "maya": "maya"
+                    "maya": "maya",
+                    "custom": "custom"
                 },
                 default=cls.abc_conversion_preset
             )
@@ -67,7 +69,7 @@ class PointCacheAlembicLoader(plugin.Loader):
         sampling_settings = unreal.AbcSamplingSettings()
         abc_conversion_preset = loaded_options.get("abc_conversion_preset")
         if abc_conversion_preset == "maya":
-            if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 4:
+            if UNREAL_VERSION.major >= 5:
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.MAYA)
             else:
@@ -77,7 +79,7 @@ class PointCacheAlembicLoader(plugin.Loader):
                     rotation=[90.0, 0.0, 0.0],
                     scale=[1.0, -1.0, 1.0])
         elif abc_conversion_preset == "3dsmax":
-            if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 4:
+            if UNREAL_VERSION.major >= 5:
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.MAX)
             else:
@@ -86,6 +88,26 @@ class PointCacheAlembicLoader(plugin.Loader):
                     flip_u=False, flip_v=True,
                     rotation=[0.0, 0.0, 0.0],
                     scale=[1.0, -1.0, 1.0])
+        else:
+            data = get_current_project_settings()
+            preset = (
+                data["unreal"]["import_settings"]["custom"]
+            )
+            conversion_settings = unreal.AbcConversionSettings(
+                preset=unreal.AbcConversionPreset.CUSTOM,
+                flip_u=preset["flip_u"],
+                flip_v=preset["flip_v"],
+                rotation=[
+                    preset["rot_x"],
+                    preset["rot_y"],
+                    preset["rot_z"]
+                ],
+                scale=[
+                    preset["scl_x"],
+                    preset["scl_y"],
+                    preset["scl_z"]
+                ]
+            )
 
         task.set_editor_property('filename', filename)
         task.set_editor_property('destination_path', asset_dir)

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -76,8 +76,8 @@ class PointCacheAlembicLoader(plugin.Loader):
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.CUSTOM,
                     flip_u=False, flip_v=True,
-                    rotation=[-90.0, 0.0, 180.0],
-                    scale=[100.0, 100.0, 100.0])
+                    rotation=[90.0, 0.0, 0.0],
+                    scale=[100.0, -100.0, 100.0])
         elif abc_conversion_preset == "3dsmax":
             if UNREAL_VERSION.major >= 5:
                 conversion_settings = unreal.AbcConversionSettings(

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -76,7 +76,7 @@ class PointCacheAlembicLoader(plugin.Loader):
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.CUSTOM,
                     flip_u=False, flip_v=True,
-                    rotation=[90.0, 0.0, 0.0],
+                    rotation=[0.0, 0.0, 0.0],
                     scale=[100.0, -100.0, 100.0])
         elif abc_conversion_preset == "3dsmax":
             if UNREAL_VERSION.major >= 5:
@@ -86,7 +86,7 @@ class PointCacheAlembicLoader(plugin.Loader):
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.CUSTOM,
                     flip_u=False, flip_v=True,
-                    rotation=[0.0, 0.0, 0.0],
+                    rotation=[90.0, 0.0, 0.0],
                     scale=[1.0, -1.0, 1.0])
         else:
             data = get_current_project_settings()

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -69,7 +69,7 @@ class PointCacheAlembicLoader(plugin.Loader):
         sampling_settings = unreal.AbcSamplingSettings()
         abc_conversion_preset = loaded_options.get("abc_conversion_preset")
         if abc_conversion_preset == "maya":
-            if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 2:
+            if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 3:
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.MAYA)
             else:

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -76,8 +76,8 @@ class PointCacheAlembicLoader(plugin.Loader):
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.CUSTOM,
                     flip_u=False, flip_v=True,
-                    rotation=[0.0, 0.0, 0.0],
-                    scale=[100.0, -100.0, 100.0])
+                    rotation=[90.0, 0.0, 0.0],
+                    scale=[1.0, -1.0, 1.0])
         elif abc_conversion_preset == "3dsmax":
             if UNREAL_VERSION.major >= 5:
                 conversion_settings = unreal.AbcConversionSettings(
@@ -86,7 +86,7 @@ class PointCacheAlembicLoader(plugin.Loader):
                 conversion_settings = unreal.AbcConversionSettings(
                     preset=unreal.AbcConversionPreset.CUSTOM,
                     flip_u=False, flip_v=True,
-                    rotation=[90.0, 0.0, 0.0],
+                    rotation=[0.0, 0.0, 0.0],
                     scale=[1.0, -1.0, 1.0])
         else:
             data = get_current_project_settings()

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -382,8 +382,8 @@ class LayoutLoader(plugin.LayoutLoader):
         sequence = None
         master_level = None
         hierarchy_dir = container.get("master_directory", "")
+        master_dir_name = get_top_hierarchy_folder(asset_dir)
         if not hierarchy_dir:
-            master_dir_name = get_top_hierarchy_folder(asset_dir)
             hierarchy_dir = f"{AYON_ROOT_DIR}/{master_dir_name}"
         if create_sequences:
             master_level = f"{hierarchy_dir}/{master_dir_name}_map.{master_dir_name}_map"

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -108,7 +108,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[90.0, 0.0, 0.0],
+                        rotation=[0.0, 0.0, 0.0],
                         scale=[100.0, -100.0, 100.0])
             elif abc_conversion_preset == "3dsmax":
                 if UNREAL_VERSION.major >= 5:
@@ -118,7 +118,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[0.0, 0.0, 0.0],
+                        rotation=[90.0, 0.0, 0.0],
                         scale=[1.0, -1.0, 1.0])
             else:
                 data = get_current_project_settings()

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -101,7 +101,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             conversion_settings = None
             abc_conversion_preset = loaded_options.get("abc_conversion_preset")
             if abc_conversion_preset == "maya":
-                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 3:
+                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 4:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAYA)
                 else:

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -108,8 +108,8 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[-90.0, 0.0, 180.0],
-                        scale=[100.0, 100.0, 100.0])
+                        rotation=[90.0, 0.0, 0.0],
+                        scale=[100.0, -100.0, 100.0])
             elif abc_conversion_preset == "3dsmax":
                 if UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -15,6 +15,7 @@ from ayon_unreal.api.pipeline import (
     format_asset_directory,
     UNREAL_VERSION
 )
+from ayon_core.settings import get_current_project_settings
 import unreal  # noqa
 
 
@@ -48,7 +49,8 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
                 label="Alembic Conversion Preset",
                 items={
                     "3dsmax": "3dsmax",
-                    "maya": "maya"
+                    "maya": "maya",
+                    "custom": "custom"
                 },
                 default=cls.abc_conversion_preset
             ),
@@ -99,7 +101,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             conversion_settings = None
             abc_conversion_preset = loaded_options.get("abc_conversion_preset")
             if abc_conversion_preset == "maya":
-                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 4:
+                if UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAYA)
                 else:
@@ -109,7 +111,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
                         rotation=[90.0, 0.0, 0.0],
                         scale=[1.0, -1.0, 1.0])
             elif abc_conversion_preset == "3dsmax":
-                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 4:
+                if UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAX)
                 else:
@@ -118,6 +120,26 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
                         flip_u=False, flip_v=True,
                         rotation=[0.0, 0.0, 0.0],
                         scale=[1.0, -1.0, 1.0])
+            else:
+                data = get_current_project_settings()
+                preset = (
+                    data["unreal"]["import_settings"]["custom"]
+                )
+                conversion_settings = unreal.AbcConversionSettings(
+                    preset=unreal.AbcConversionPreset.CUSTOM,
+                    flip_u=preset["flip_u"],
+                    flip_v=preset["flip_v"],
+                    rotation=[
+                        preset["rot_x"],
+                        preset["rot_y"],
+                        preset["rot_z"]
+                    ],
+                    scale=[
+                        preset["scl_x"],
+                        preset["scl_y"],
+                        preset["scl_z"]
+                    ]
+                )
 
             options.conversion_settings = conversion_settings
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -101,7 +101,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             conversion_settings = None
             abc_conversion_preset = loaded_options.get("abc_conversion_preset")
             if abc_conversion_preset == "maya":
-                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 2:
+                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 3:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAYA)
                 else:

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -108,8 +108,8 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[0.0, 0.0, 0.0],
-                        scale=[100.0, -100.0, 100.0])
+                        rotation=[90.0, 0.0, 0.0],
+                        scale=[1.0, -1.0, 1.0])
             elif abc_conversion_preset == "3dsmax":
                 if UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(
@@ -118,7 +118,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[90.0, 0.0, 0.0],
+                        rotation=[0.0, 0.0, 0.0],
                         scale=[1.0, -1.0, 1.0])
             else:
                 data = get_current_project_settings()

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -101,15 +101,15 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             conversion_settings = None
             abc_conversion_preset = loaded_options.get("abc_conversion_preset")
             if abc_conversion_preset == "maya":
-                if UNREAL_VERSION.major >= 5:
+                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 2:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAYA)
                 else:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[90.0, 0.0, 0.0],
-                        scale=[1.0, -1.0, 1.0])
+                        rotation=[-90.0, 0.0, 180.0],
+                        scale=[100.0, 100.0, 100.0])
             elif abc_conversion_preset == "3dsmax":
                 if UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -118,8 +118,8 @@ class StaticMeshAlembicLoader(plugin.Loader):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[0.0, 0.0, 0.0],
-                        scale=[100.0, -100.0, 100.0])
+                        rotation=[90.0, 0.0, 0.0],
+                        scale=[1.0, -1.0, 1.0])
             elif abc_conversion_preset == "3dsmax":
                 if UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(
@@ -128,7 +128,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[90.0, 0.0, 0.0],
+                        rotation=[0.0, 0.0, 0.0],
                         scale=[1.0, -1.0, 1.0])
             else:
                 data = get_current_project_settings()

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -111,7 +111,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
             conversion_settings = None
             abc_conversion_preset = loaded_options.get("abc_conversion_preset")
             if abc_conversion_preset == "maya":
-                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 3:
+                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 4:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAYA)
                 else:

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -14,6 +14,7 @@ from ayon_unreal.api.pipeline import (
     format_asset_directory,
     UNREAL_VERSION
 )
+from ayon_core.settings import get_current_project_settings
 from ayon_core.lib import EnumDef, BoolDef
 import unreal  # noqa
 
@@ -49,7 +50,8 @@ class StaticMeshAlembicLoader(plugin.Loader):
                 label="Alembic Conversion Preset",
                 items={
                     "3dsmax": "3dsmax",
-                    "maya": "maya"
+                    "maya": "maya",
+                    "custom": "custom"
                 },
                 default=cls.abc_conversion_preset
             ),
@@ -109,7 +111,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
             conversion_settings = None
             abc_conversion_preset = loaded_options.get("abc_conversion_preset")
             if abc_conversion_preset == "maya":
-                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 4:
+                if UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAYA)
                 else:
@@ -119,7 +121,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
                         rotation=[90.0, 0.0, 0.0],
                         scale=[1.0, -1.0, 1.0])
             elif abc_conversion_preset == "3dsmax":
-                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 4:
+                if UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAX)
                 else:
@@ -128,6 +130,26 @@ class StaticMeshAlembicLoader(plugin.Loader):
                         flip_u=False, flip_v=True,
                         rotation=[0.0, 0.0, 0.0],
                         scale=[1.0, -1.0, 1.0])
+            else:
+                data = get_current_project_settings()
+                preset = (
+                    data["unreal"]["import_settings"]["custom"]
+                )
+                conversion_settings = unreal.AbcConversionSettings(
+                    preset=unreal.AbcConversionPreset.CUSTOM,
+                    flip_u=preset["flip_u"],
+                    flip_v=preset["flip_v"],
+                    rotation=[
+                        preset["rot_x"],
+                        preset["rot_y"],
+                        preset["rot_z"]
+                    ],
+                    scale=[
+                        preset["scl_x"],
+                        preset["scl_y"],
+                        preset["scl_z"]
+                    ]
+                )
             options.conversion_settings = conversion_settings
 
         options.static_mesh_settings = sm_settings

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -118,7 +118,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[90.0, 0.0, 0.0],
+                        rotation=[0.0, 0.0, 0.0],
                         scale=[100.0, -100.0, 100.0])
             elif abc_conversion_preset == "3dsmax":
                 if UNREAL_VERSION.major >= 5:
@@ -128,7 +128,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[0.0, 0.0, 0.0],
+                        rotation=[90.0, 0.0, 0.0],
                         scale=[1.0, -1.0, 1.0])
             else:
                 data = get_current_project_settings()

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -111,15 +111,15 @@ class StaticMeshAlembicLoader(plugin.Loader):
             conversion_settings = None
             abc_conversion_preset = loaded_options.get("abc_conversion_preset")
             if abc_conversion_preset == "maya":
-                if UNREAL_VERSION.major >= 5:
+                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 2:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAYA)
                 else:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[90.0, 0.0, 0.0],
-                        scale=[1.0, -1.0, 1.0])
+                        rotation=[-90.0, 0.0, 180.0],
+                        scale=[100.0, 100.0, 100.0])
             elif abc_conversion_preset == "3dsmax":
                 if UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -111,7 +111,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
             conversion_settings = None
             abc_conversion_preset = loaded_options.get("abc_conversion_preset")
             if abc_conversion_preset == "maya":
-                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 2:
+                if UNREAL_VERSION.major >= 5 and UNREAL_VERSION.minor >= 3:
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.MAYA)
                 else:

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -118,8 +118,8 @@ class StaticMeshAlembicLoader(plugin.Loader):
                     conversion_settings = unreal.AbcConversionSettings(
                         preset=unreal.AbcConversionPreset.CUSTOM,
                         flip_u=False, flip_v=True,
-                        rotation=[-90.0, 0.0, 180.0],
-                        scale=[100.0, 100.0, 100.0])
+                        rotation=[90.0, 0.0, 0.0],
+                        scale=[100.0, -100.0, 100.0])
             elif abc_conversion_preset == "3dsmax":
                 if UNREAL_VERSION.major >= 5:
                     conversion_settings = unreal.AbcConversionSettings(

--- a/server/import_settings.py
+++ b/server/import_settings.py
@@ -12,7 +12,8 @@ def _loaded_asset_enum():
 def _abc_conversion_presets_enum():
     return [
         {"value": "maya", "label": "maya"},
-        {"value": "3dsmax", "label": "3dsmax"}
+        {"value": "3dsmax", "label": "3dsmax"},
+        {"value": "custom", "label": "custom"},
     ]
 
 
@@ -29,6 +30,17 @@ class UnrealInterchangeModel(BaseSettingsModel):
         title="path to texture pipeline",
         description="Path to the Interchange pipeline asset."
                     "Right-click asset and copy reference path.")
+
+
+class CustomAlembicPresetsModel(BaseSettingsModel):
+    flip_u: bool = SettingsField(False, title="Flip U")
+    flip_v: bool = SettingsField(True, title="Flip V")
+    rot_x: float = SettingsField(90.0, title="Rotation X")
+    rot_y: float = SettingsField(0.0, title="Rotation Y")
+    rot_z: float = SettingsField(0.0, title="Rotation Z")
+    scl_x: float = SettingsField(1.0, title="Scale X")
+    scl_y: float = SettingsField(-1.0, title="Scale Y")
+    scl_z: float = SettingsField(1.0, title="Scale Z")
 
 
 class UnrealImportModel(BaseSettingsModel):
@@ -62,12 +74,17 @@ class UnrealImportModel(BaseSettingsModel):
     abc_conversion_preset: str = SettingsField(
         "maya",
         title="Alembic Conversion Setting Presets",
-        enum_resolver=_abc_conversion_presets_enum,
         description="Presets for converting the loaded alembic "
                     "with correct UV and transform",
+        enum_resolver=_abc_conversion_presets_enum,
+        conditionalEnum=True,
         section="Load Alembic Settings"
     )
-
+    custom: CustomAlembicPresetsModel = SettingsField(
+        title="Custom Alembic Conversion Setting Presets",
+        description="Custom Presets for converting the loaded alembic",
+        default_factory=CustomAlembicPresetsModel,
+    )
     loaded_layout_dir: str = SettingsField(
         "{folder[path]}/{product[name]}",
         title="Directories for loaded layouts",


### PR DESCRIPTION
## Changelog Description
This PR is to backport load transform to older UE versions(4.27), and the new alembic conversion presets supports in Unreal 5. 
https://dev.epicgames.com/documentation/en-us/unreal-engine/python-api/class/AbcConversionPreset?application_version=5.0#unreal.AbcConversionPreset 
Also it introduces the custom alembic conversion presets of which user can choose to set it in ayon settings if the transform is still not what they want. 
![image](https://github.com/user-attachments/assets/4597e550-d2f6-4707-b96e-98c805cc87f9)
Resolve #179 
## Additional review information
Please install and build addon with this branch to update the settings
Test it in 5.1 if possible

## Testing notes:
1. Try the default alembic presets
2. Load Asset in alembic format (Animation, PointCache, Model, Layout)
3. Switch the alembic presets to `custom`
4. Load Asset in alembic format (Animation, PointCache, Model, Layout)
