### PR TITLE
Use correct variable for syncing the force-loaded enable button

### DIFF
--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -38,8 +38,8 @@ class LayoutLoader(plugin.LayoutLoader):
     """Load Layout from a JSON file"""
 
     label = "Load Layout"
-    folder_representation_type = "json"
     force_loaded = False
+    folder_representation_type = "json"
     level_sequences_for_layouts = True
 
     @classmethod
@@ -47,10 +47,10 @@ class LayoutLoader(plugin.LayoutLoader):
         super(LayoutLoader, cls).apply_settings(project_settings)
         # Apply import settings
         import_settings = project_settings["unreal"]["import_settings"]
+        cls.force_loaded = import_settings["force_loaded"]
         cls.folder_representation_type = (
             import_settings["folder_representation_type"]
         )
-        cls.use_force_loaded = import_settings["force_loaded"]
         cls.level_sequences_for_layouts = (
             import_settings["level_sequences_for_layouts"]
         )


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the correct variable name has been used for syncing the force-loaded enabling function from ayon setting

## Additional review information
n/a

## Testing notes:
1. Go to enable `ayon+settings://unreal/import_settings/force_loaded`
2. Launch Unreal
3. You can find the enable button in the loader and overriding representation type should be working.
