### PR TITLE
adding AnimationAlembicLoader support into LayoutLoader

### DIFF
--- a/client/ayon_unreal/api/plugin.py
+++ b/client/ayon_unreal/api/plugin.py
@@ -328,6 +328,8 @@ class LayoutLoader(Loader):
             name = "SkeletalMeshAlembicLoader"
         elif family in ['model', 'staticMesh']:
             name = "StaticMeshAlembicLoader"
+        elif family in ['animation']:
+            name = "AnimationAlembicLoader"
 
         if name == "":
             return None


### PR DESCRIPTION
## Changelog Description
This PR is to add support for importing alembic animations into Unreal when they are included in a layout as part of the load layout step.

## Additional review information
Although the alembic animations in the layout will now be loaded, they are not yet added to the corresponding LevelSequence.

## Testing notes:
1. Publish a layout containing an animation with an abc representation.
2. Launch Unreal
3. Load layout
4. Alembic animation should be loaded
