### PR TITLE
Use interchange pipeline path in ayon setting for interchange import workflow

### DIFF
--- a/client/ayon_unreal/plugins/load/load_image_png.py
+++ b/client/ayon_unreal/plugins/load/load_image_png.py
@@ -93,7 +93,7 @@ class TexturePNGLoader(plugin.Loader):
                                              import_asset_parameters)
 
             if not unreal.EditorAssetLibrary.does_directory_exist(self.pipeline_path):
-                editor_asset_subsystem.delete_asset(self.pipeline_path)
+                editor_asset_subsystem.delete_directory(self.pipeline_path)
 
         else:
             self.log.info("Import using deferred method")

--- a/client/ayon_unreal/plugins/load/load_image_png.py
+++ b/client/ayon_unreal/plugins/load/load_image_png.py
@@ -83,8 +83,9 @@ class TexturePNGLoader(plugin.Loader):
             editor_asset_subsystem = unreal.EditorAssetSubsystem()
             import_asset_parameters.is_automated = bool(not self.show_dialog)
             if not unreal.EditorAssetLibrary.does_directory_exist(self.pipeline_path):
+                transient_obj_path = self.pipeline_path.split("/")[-1]
                 import_asset_parameters.override_pipelines.append(
-                    unreal.SoftObjectPath(f"{self.pipeline_path}"))
+                    unreal.SoftObjectPath(f"{self.pipeline_path}.{transient_obj_path}"))
 
             source_data = unreal.InterchangeManager.create_source_data(
                 filepath)

--- a/client/ayon_unreal/plugins/load/load_image_png.py
+++ b/client/ayon_unreal/plugins/load/load_image_png.py
@@ -29,7 +29,6 @@ class TexturePNGLoader(plugin.Loader):
     # Defined by settings
     use_interchange = False
     show_dialog = False
-    pipeline_path = ""
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
 
     @classmethod
@@ -42,9 +41,6 @@ class TexturePNGLoader(plugin.Loader):
             "enabled", cls.use_interchange
         )
         cls.show_dialog = import_settings.get("show_dialog", cls.show_dialog)
-        cls.pipeline_path = import_settings.get("interchange", {}).get(
-            "pipeline_path_textures", cls.pipeline_path
-        )
         cls.loaded_asset_dir = import_settings.get(
             "loaded_asset_dir", cls.loaded_asset_dir)
 
@@ -80,22 +76,13 @@ class TexturePNGLoader(plugin.Loader):
                 None, "Interchange.FeatureFlags.Import.EXR 1")
 
             import_asset_parameters = unreal.ImportAssetParameters()
-            editor_asset_subsystem = unreal.EditorAssetSubsystem()
             import_asset_parameters.is_automated = bool(not self.show_dialog)
-            if not unreal.EditorAssetLibrary.does_directory_exist(self.pipeline_path):
-                transient_obj_path = self.pipeline_path.split("/")[-1]
-                import_asset_parameters.override_pipelines.append(
-                    unreal.SoftObjectPath(f"{self.pipeline_path}.{transient_obj_path}"))
 
             source_data = unreal.InterchangeManager.create_source_data(
                 filepath)
             interchange_manager = unreal.InterchangeManager.get_interchange_manager_scripted()  # noqa
             interchange_manager.import_asset(asset_dir, source_data,
                                              import_asset_parameters)
-
-            if not unreal.EditorAssetLibrary.does_directory_exist(self.pipeline_path):
-                editor_asset_subsystem.delete_directory(self.pipeline_path)
-
         else:
             self.log.info("Import using deferred method")
             task = None

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -10,7 +10,6 @@ from ayon_unreal.api import plugin
 from ayon_unreal.api.pipeline import (
     create_container,
     imprint,
-    has_asset_directory_pattern_matched,
     format_asset_directory
 )
 import unreal  # noqa
@@ -25,7 +24,6 @@ class StaticMeshFBXLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
 
-    use_interchange = False
     use_nanite = True
     show_dialog = False
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
@@ -73,31 +71,17 @@ class StaticMeshFBXLoader(plugin.Loader):
 
     @classmethod
     def import_and_containerize(
-        cls, filepath, asset_dir, asset_name, container_name, asset_path=None
+        cls, filepath, asset_dir, container_name
     ):
-        if cls.use_interchange:
-            unreal.log("Import using interchange method")
-            unreal.SystemLibrary.execute_console_command(None, "Interchange.FeatureFlags.Import.FBX 1")
+        unreal.log("Import using interchange method")
+        unreal.SystemLibrary.execute_console_command(None, "Interchange.FeatureFlags.Import.FBX 1")
 
-            import_asset_parameters = unreal.ImportAssetParameters()
-            import_asset_parameters.is_automated = not cls.show_dialog
+        import_asset_parameters = unreal.ImportAssetParameters()
+        import_asset_parameters.is_automated = not cls.show_dialog
 
-            source_data = unreal.InterchangeManager.create_source_data(filepath)
-            interchange_manager = unreal.InterchangeManager.get_interchange_manager_scripted()
-            interchange_manager.import_asset(asset_dir, source_data,
-                                             import_asset_parameters)
-        else:
-            unreal.log("Import using deferred method")
-            task = None
-            if asset_path:
-                loaded_asset_dir = unreal.Paths.split(asset_path)[0]
-                task = cls.get_task(filepath, loaded_asset_dir, asset_name, True)
-            else:
-                if not unreal.EditorAssetLibrary.does_asset_exist(
-                    f"{asset_dir}/{asset_name}"):
-                        task = cls.get_task(filepath, asset_dir, asset_name, False)
-
-            unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+        source_data = unreal.InterchangeManager.create_source_data(filepath)
+        interchange_manager = unreal.InterchangeManager.get_interchange_manager_scripted()
+        interchange_manager.import_asset(asset_dir, source_data, import_asset_parameters)
 
         if not unreal.EditorAssetLibrary.does_asset_exist(
             f"{asset_dir}/{container_name}"):
@@ -159,21 +143,10 @@ class StaticMeshFBXLoader(plugin.Loader):
             asset_root, suffix=f"_{ext}")
 
         container_name += suffix
-        asset_path = (
-            has_asset_directory_pattern_matched(asset_name, asset_dir, name, extension=ext)
-            if not self.use_interchange else None
-        )
+
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             unreal.EditorAssetLibrary.make_directory(asset_dir)
-        self.import_and_containerize(
-            path, asset_dir, asset_name,
-            container_name, asset_path=asset_path
-        )
-        if asset_path:
-            unreal.EditorAssetLibrary.rename_asset(
-                f"{asset_path}",
-                f"{asset_dir}/{asset_name}.{asset_name}"
-            )
+        self.import_and_containerize(path, asset_dir, container_name)
 
         self.imprint(
             folder_path,
@@ -212,8 +185,7 @@ class StaticMeshFBXLoader(plugin.Loader):
         container_name += suffix
         if not unreal.EditorAssetLibrary.does_directory_exist(asset_dir):
             unreal.EditorAssetLibrary.make_directory(asset_dir)
-        self.import_and_containerize(path, asset_dir, asset_name,
-                                     container_name)
+        self.import_and_containerize(path, asset_dir, container_name)
 
         self.imprint(
             folder_path,

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -28,7 +28,6 @@ class StaticMeshFBXLoader(plugin.Loader):
     use_interchange = False
     use_nanite = True
     show_dialog = False
-    pipeline_path = ""
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
 
     @classmethod
@@ -42,9 +41,6 @@ class StaticMeshFBXLoader(plugin.Loader):
         )
         cls.show_dialog = import_settings.get("show_dialog", cls.show_dialog)
         cls.use_nanite = import_settings.get("use_nanite", cls.use_nanite)
-        cls.pipeline_path = import_settings.get("interchange", {}).get(
-            "pipeline_path_static_mesh", cls.pipeline_path
-        )
         cls.loaded_asset_dir = import_settings.get(
             "loaded_asset_dir", cls.loaded_asset_dir)
 
@@ -84,22 +80,12 @@ class StaticMeshFBXLoader(plugin.Loader):
             unreal.SystemLibrary.execute_console_command(None, "Interchange.FeatureFlags.Import.FBX 1")
 
             import_asset_parameters = unreal.ImportAssetParameters()
-            editor_asset_subsystem = unreal.EditorAssetSubsystem()
             import_asset_parameters.is_automated = not cls.show_dialog
-
-            if not unreal.EditorAssetLibrary.does_directory_exist(cls.pipeline_path):
-                transient_obj_path = cls.pipeline_path.split("/")[-1]
-                import_asset_parameters.override_pipelines.append(
-                    unreal.SoftObjectPath(f"{cls.pipeline_path}.{transient_obj_path}"))
 
             source_data = unreal.InterchangeManager.create_source_data(filepath)
             interchange_manager = unreal.InterchangeManager.get_interchange_manager_scripted()
             interchange_manager.import_asset(asset_dir, source_data,
                                              import_asset_parameters)
-
-            if not unreal.EditorAssetLibrary.does_directory_exist(cls.pipeline_path):
-                editor_asset_subsystem.delete_directory(cls.pipeline_path) # remove temp file
-
         else:
             unreal.log("Import using deferred method")
             task = None

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -88,8 +88,9 @@ class StaticMeshFBXLoader(plugin.Loader):
             import_asset_parameters.is_automated = not cls.show_dialog
 
             if not unreal.EditorAssetLibrary.does_directory_exist(cls.pipeline_path):
+                transient_obj_path = cls.pipeline_path.split("/")[-1]
                 import_asset_parameters.override_pipelines.append(
-                    unreal.SoftObjectPath(f"{cls.pipeline_path}"))
+                    unreal.SoftObjectPath(f"{cls.pipeline_path}.{transient_obj_path}"))
 
             source_data = unreal.InterchangeManager.create_source_data(filepath)
             interchange_manager = unreal.InterchangeManager.get_interchange_manager_scripted()

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -83,28 +83,21 @@ class StaticMeshFBXLoader(plugin.Loader):
             unreal.log("Import using interchange method")
             unreal.SystemLibrary.execute_console_command(None, "Interchange.FeatureFlags.Import.FBX 1")
 
-            import_assetparameters = unreal.ImportAssetParameters()
+            import_asset_parameters = unreal.ImportAssetParameters()
             editor_asset_subsystem = unreal.EditorAssetSubsystem()
-            import_assetparameters.is_automated = not cls.show_dialog
+            import_asset_parameters.is_automated = not cls.show_dialog
 
-            # The path to the Interchange asset
-            tmp_pipeline_path = "/Game/tmp"
-            # interchange settings here
-            unreal.EditorAssetLibrary.rename_asset(
-                f"{cls.pipeline_path}",
-                f"{tmp_pipeline_path}/{asset_name}.{asset_name}"
-            )
-
-            import_assetparameters.override_pipelines.append(
-                unreal.SoftObjectPath(f"{tmp_pipeline_path}.tmp"))
+            if not unreal.EditorAssetLibrary.does_directory_exist(cls.pipeline_path):
+                import_asset_parameters.override_pipelines.append(
+                    unreal.SoftObjectPath(f"{cls.pipeline_path}"))
 
             source_data = unreal.InterchangeManager.create_source_data(filepath)
             interchange_manager = unreal.InterchangeManager.get_interchange_manager_scripted()
             interchange_manager.import_asset(asset_dir, source_data,
-                                            import_assetparameters)
+                                             import_asset_parameters)
 
-
-            editor_asset_subsystem.delete_asset(tmp_pipeline_path) # remove temp file
+            if not unreal.EditorAssetLibrary.does_directory_exist(cls.pipeline_path):
+                editor_asset_subsystem.delete_directory(cls.pipeline_path) # remove temp file
 
         else:
             unreal.log("Import using deferred method")

--- a/server/import_settings.py
+++ b/server/import_settings.py
@@ -17,11 +17,6 @@ def _abc_conversion_presets_enum():
     ]
 
 
-class UnrealInterchangeModel(BaseSettingsModel):
-    """Define Interchange Pipeline Asset Paths"""
-    enabled: bool = SettingsField(False, title="enabled")
-
-
 class CustomAlembicPresetsModel(BaseSettingsModel):
     flip_u: bool = SettingsField(False, title="Flip U")
     flip_v: bool = SettingsField(True, title="Flip V")
@@ -42,12 +37,6 @@ class UnrealImportModel(BaseSettingsModel):
         title="Asset directories for loaded assets",
         description="Asset directories to store the loaded assets",
 
-    )
-
-    interchange: UnrealInterchangeModel = SettingsField(
-        default_factory=UnrealInterchangeModel,
-        title="Interchange pipeline",
-        section="Load Fbx Settings"
     )
 
     use_nanite: bool = SettingsField(True,
@@ -113,9 +102,6 @@ class UnrealImportModel(BaseSettingsModel):
 
 DEFAULT_IMPORT_SETTINGS = {
     "loaded_asset_dir": "{folder[path]}/{product[name]}_{version[version]}",
-    "interchange": {
-        "enabled": False
-    },
     "use_nanite": True,
     "show_dialog": False,
     "abc_conversion_preset": "maya",

--- a/server/import_settings.py
+++ b/server/import_settings.py
@@ -125,8 +125,8 @@ DEFAULT_IMPORT_SETTINGS = {
     "loaded_asset_dir": "{folder[path]}/{product[name]}_{version[version]}",
     "interchange": {
         "enabled": False,
-        "pipeline_path_static_mesh": "/Game/Interchange/CustomPipeline.CustomPipeline",
-        "pipeline_path_textures": "/Game/Interchange/CustomPipeline.CustomPipeline",
+        "pipeline_path_static_mesh": "/Game/Interchange/CustomPipeline",
+        "pipeline_path_textures": "/Game/Interchange/CustomPipeline",
     },
     "use_nanite": True,
     "show_dialog": False,

--- a/server/import_settings.py
+++ b/server/import_settings.py
@@ -20,16 +20,6 @@ def _abc_conversion_presets_enum():
 class UnrealInterchangeModel(BaseSettingsModel):
     """Define Interchange Pipeline Asset Paths"""
     enabled: bool = SettingsField(False, title="enabled")
-    pipeline_path_static_mesh: str = SettingsField(
-        "/Game/Interchange/CustomPipeline.CustomPipeline",
-        title="path to static mesh pipeline",
-        description="Path to the Interchange pipeline asset."
-                    "Right-click asset and copy reference path.")
-    pipeline_path_textures: str = SettingsField(
-        "/Game/Interchange/CustomPipeline.CustomPipeline",
-        title="path to texture pipeline",
-        description="Path to the Interchange pipeline asset."
-                    "Right-click asset and copy reference path.")
 
 
 class CustomAlembicPresetsModel(BaseSettingsModel):
@@ -124,9 +114,7 @@ class UnrealImportModel(BaseSettingsModel):
 DEFAULT_IMPORT_SETTINGS = {
     "loaded_asset_dir": "{folder[path]}/{product[name]}_{version[version]}",
     "interchange": {
-        "enabled": False,
-        "pipeline_path_static_mesh": "/Game/Interchange/CustomPipeline",
-        "pipeline_path_textures": "/Game/Interchange/CustomPipeline",
+        "enabled": False
     },
     "use_nanite": True,
     "show_dialog": False,

--- a/server/import_settings.py
+++ b/server/import_settings.py
@@ -125,8 +125,8 @@ DEFAULT_IMPORT_SETTINGS = {
     "loaded_asset_dir": "{folder[path]}/{product[name]}_{version[version]}",
     "interchange": {
         "enabled": False,
-        "pipeline_path_static_mesh": "/Game/Interchange/CustomPipeline",
-        "pipeline_path_textures": "/Game/Interchange/CustomPipeline",
+        "pipeline_path_static_mesh": "/Game/Interchange/CustomPipeline.CustomPipeline",
+        "pipeline_path_textures": "/Game/Interchange/CustomPipeline.CustomPipeline",
     },
     "use_nanite": True,
     "show_dialog": False,


### PR DESCRIPTION
## Changelog Description
This PR is to remove the custom pipeline path for the current interchange workflow of importing asset. Users/System can decide which path to use for the interchange workflow.

## Additional review information
n/a

## Testing notes:
1. Enable `ayon+settings://unreal/import_settings/interchange/enabled`
2. Load static mesh in fbx or image in Unreal
