### PR TITLE
Adjustment of the orientation for fbx animation import in 5.5

### DIFF
--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -7,7 +7,8 @@ import unreal
 from ayon_core.pipeline import (AYON_CONTAINER_ID, get_current_project_name,
                                 get_representation_path, load_container,
                                 discover_loader_plugins,
-                                loaders_from_representation)
+                                loaders_from_representation,
+                                UNREAL_VERSION)
 from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.pipeline.load import LoadError
 from ayon_unreal.api import pipeline as unreal_pipeline
@@ -124,8 +125,11 @@ class AnimationFBXLoader(plugin.Loader):
             'convert_scene', True)
         task.options.anim_sequence_import_data.set_editor_property(
             'force_front_x_axis', False)
-        task.options.anim_sequence_import_data.set_editor_property(
-            'import_rotation', unreal.Rotator(roll=90.0, pitch=0.0, yaw=0.0))
+        if UNREAL_VERSION.major == 5 and UNREAL_VERSION.minor <=4 :
+            task.options.anim_sequence_import_data.set_editor_property(
+                'import_rotation',
+                unreal.Rotator(roll=90.0, pitch=0.0, yaw=0.0)
+        )
 
         unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
 

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -7,8 +7,7 @@ import unreal
 from ayon_core.pipeline import (AYON_CONTAINER_ID, get_current_project_name,
                                 get_representation_path, load_container,
                                 discover_loader_plugins,
-                                loaders_from_representation,
-                                UNREAL_VERSION)
+                                loaders_from_representation)
 from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.pipeline.load import LoadError
 from ayon_unreal.api import pipeline as unreal_pipeline
@@ -125,11 +124,13 @@ class AnimationFBXLoader(plugin.Loader):
             'convert_scene', True)
         task.options.anim_sequence_import_data.set_editor_property(
             'force_front_x_axis', False)
-        if UNREAL_VERSION.major == 5 and UNREAL_VERSION.minor <=4 :
-            task.options.anim_sequence_import_data.set_editor_property(
-                'import_rotation',
-                unreal.Rotator(roll=90.0, pitch=0.0, yaw=0.0)
-        )
+        if unreal_pipeline.UNREAL_VERSION.major == 5 and (
+            unreal_pipeline.UNREAL_VERSION.minor <=4
+            ):
+                task.options.anim_sequence_import_data.set_editor_property(
+                    'import_rotation',
+                    unreal.Rotator(roll=90.0, pitch=0.0, yaw=0.0)
+                )
 
         unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
 


### PR DESCRIPTION
## Changelog Description
Fix https://github.com/ynput/ayon-unreal/issues/191
This PR is to make sure the correct x rotation of the animation sequence when performing connect action with layout and animation product in fbx.

## Additional review information
n/a

## Testing notes:
1. Launch Unreal in the launcher which installed with the built addon of this branch
2. Load Layout and fbx animation
3. Go to manage
4. Select layout and fbx animation container and perform connect action.
