### PR TITLE
Chore: Removed usage of 'six'

### DIFF
--- a/client/ayon_unreal/api/plugin.py
+++ b/client/ayon_unreal/api/plugin.py
@@ -1,12 +1,7 @@
 # -*- coding: utf-8 -*-
 import ast
 import collections
-import sys
-import six
-from abc import (
-    ABC,
-    ABCMeta,
-)
+from abc import ABC
 
 import unreal
 import ayon_api
@@ -152,11 +147,8 @@ class UnrealCreateLogic():
 
             return instance
 
-        except Exception as er:
-            six.reraise(
-                CreatorError,
-                CreatorError(f"Creator error: {er}"),
-                sys.exc_info()[2])
+        except Exception as exc:
+            raise CreatorError(f"Creator error: {exc}") from exc
 
 
 class UnrealBaseAutoCreator(AutoCreator, UnrealCreateLogic):
@@ -219,11 +211,8 @@ class UnrealAssetCreator(UnrealBaseCreator):
                 instance_data,
                 pre_create_data)
 
-        except Exception as er:
-            six.reraise(
-                CreatorError,
-                CreatorError(f"Creator error: {er}"),
-                sys.exc_info()[2])
+        except Exception as exc:
+            raise CreatorError(f"Creator error: {exc}") from exc
 
     def get_pre_create_attr_defs(self):
         return [
@@ -231,7 +220,6 @@ class UnrealAssetCreator(UnrealBaseCreator):
         ]
 
 
-@six.add_metaclass(ABCMeta)
 class UnrealActorCreator(UnrealBaseCreator):
     """Base class for Unreal creator plugins based on actors."""
 
@@ -272,11 +260,8 @@ class UnrealActorCreator(UnrealBaseCreator):
                 instance_data,
                 pre_create_data)
 
-        except Exception as er:
-            six.reraise(
-                CreatorError,
-                CreatorError(f"Creator error: {er}"),
-                sys.exc_info()[2])
+        except Exception as exc:
+            raise CreatorError(f"Creator error: {exc}") from exc
 
     def get_pre_create_attr_defs(self):
         return [


### PR DESCRIPTION
## Changelog Description
Removed `six` module usage.

## Note
I don't understand why `Loader` does inherit from `ABC`, because it does not have any `abstractmethod` defined?