### PR TITLE
Set module ayon-unreal-plugin to main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "client/ayon_unreal/integration"]
 	path = client/ayon_unreal/integration
 	url = https://github.com/ynput/ayon-unreal-plugin.git
+	branch = main


### PR DESCRIPTION
## Changelog Description
resolve #206 

## Testing notes:
1. submodule should point to `main`.
