### PR TITLE
:bug: remove walrus operator

### DIFF
--- a/client/ayon_unreal/addon.py
+++ b/client/ayon_unreal/addon.py
@@ -46,9 +46,10 @@ class UnrealAddon(AYONAddon, IHostAddon):
             UNREAL_ADDON_ROOT, "integration", f"UE_{ue_version}", "Ayon"
         )
         if not Path(unreal_plugin_path).exists():
-            if compatible_versions := get_compatible_integration(
+            compatible_versions = get_compatible_integration(
                 ue_version, Path(UNREAL_ADDON_ROOT) / "integration"
-            ):
+            )
+            if compatible_versions:
                 unreal_plugin_path = compatible_versions[-1] / "Ayon"
                 unreal_plugin_path = unreal_plugin_path.as_posix()
 


### PR DESCRIPTION
## Changelog Description
Remove usage of the walrus operator (`:=`) in addon as it breaks python 3.7 hosts.

## Additional review information
The walrus operator was introduced in Python 3.8. Since addon logic is executed outside AYON process too, this is crashing when running on 3.7 based hosts. It is probably cosmetic, but it pollutes error logs in those hosts. Until complete support for 3.7 is dropped, we shouldn't use it.

## Testing notes:
Unreal addon should work as expected, no mentions of crashing `addon.py` when running python 3.7 hosts (like older Maya, 3dequalizer, Mocha 2022, etc.)
