### PR TITLE
Remove unused use_interchange property

### DIFF
--- a/client/ayon_unreal/plugins/load/load_image_png.py
+++ b/client/ayon_unreal/plugins/load/load_image_png.py
@@ -35,9 +35,6 @@ class TexturePNGLoader(plugin.Loader):
         unreal_settings = project_settings.get("unreal", {})
         # Apply import settings
         import_settings = unreal_settings.get("import_settings", {})
-        cls.use_interchange = import_settings.get("interchange", {}).get(
-            "enabled", cls.use_interchange
-        )
         cls.show_dialog = import_settings.get("show_dialog", cls.show_dialog)
         cls.loaded_asset_dir = import_settings.get(
             "loaded_asset_dir", cls.loaded_asset_dir)

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -34,9 +34,6 @@ class StaticMeshFBXLoader(plugin.Loader):
         # Apply import settings
         unreal_settings = project_settings.get("unreal", {})
         import_settings = unreal_settings.get("import_settings", {})
-        cls.use_interchange = import_settings.get("interchange", {}).get(
-            "enabled", cls.use_interchange
-        )
         cls.show_dialog = import_settings.get("show_dialog", cls.show_dialog)
         cls.use_nanite = import_settings.get("use_nanite", cls.use_nanite)
         cls.loaded_asset_dir = import_settings.get(


### PR DESCRIPTION
The "use_interchange" property is not used, but is still accessed in "apply_settings" in two loaders, which is causing an error.

## Changelog Description
Fix "Loader has no attribute 'use_interchange'" error when importing static meshes and images

## Additional review information
This is also fixes having "show import dialog" enabled not having an effect for static mesh import.

## Testing notes:
1. import static mesh or texture from the loader
2. It should import without errors
