### PR TITLE
Asset Level map should be added into Project Level Map during layout load

### DIFF
--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -1142,15 +1142,14 @@ def generate_master_level_sequence(tools, asset_dir, asset_name,
             f"{asset_dir}/{asset_name}_map_{suffix}.{asset_name}_map_{suffix}"
         )
 
-    unreal.log(f"asset_level: {asset_level}")
     if not unreal.EditorAssetLibrary.does_asset_exist(asset_level):
         unreal.EditorLevelLibrary.new_level(asset_level)
-        unreal.EditorLevelLibrary.load_level(master_level)
-        unreal.EditorLevelUtils.add_level_to_world(
-            unreal.EditorLevelLibrary.get_editor_world(),
-            asset_level,
-            unreal.LevelStreamingDynamic
-        )
+    unreal.EditorLevelLibrary.load_level(master_level)
+    unreal.EditorLevelUtils.add_level_to_world(
+        unreal.EditorLevelLibrary.get_editor_world(),
+        asset_level,
+        unreal.LevelStreamingDynamic
+    )
     sequences = []
     frame_ranges = []
     root_content = unreal.EditorAssetLibrary.list_assets(


### PR DESCRIPTION
## Changelog Description
This PR is to ensure asset level map would be added into the Project Level Map during layout load, as if in the past

## Additional review information
n/a 

## Testing notes:
1. Launch Unreal
2. Load multiple Layout
3. Open your Project level map(for example if your project name is `Hello`, it should be named as`/Game/Ayon/Hello_map.Hello_map`
4. Layout loading from your asset level should be showed as children level of the Persistent level in level editor 
