### PR TITLE
Add change context dialog

### DIFF
--- a/client/ayon_unreal/api/tools_ui.py
+++ b/client/ayon_unreal/api/tools_ui.py
@@ -5,7 +5,17 @@ from ayon_core import (
     resources,
     style
 )
+
+from ayon_core.pipeline import (
+    get_current_folder_path,
+    get_current_task_name,
+)
+
+import ayon_api
+
+from ayon_core.pipeline.context_tools import change_current_context
 from ayon_core.tools.utils import host_tools
+from ayon_core.tools import context_dialog
 from ayon_core.tools.utils.lib import qt_app_context
 from ayon_unreal.api import rendering
 from ayon_unreal.api import hierarchy
@@ -18,6 +28,14 @@ class ToolsBtnsWidget(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super(ToolsBtnsWidget, self).__init__(parent)
 
+        current_context_string = (
+            f"Context: {get_current_task_name()} - "
+            f"{get_current_folder_path()}"
+        )
+        self.context_btn = QtWidgets.QPushButton(current_context_string, self)
+        self.context_btn.setToolTip(
+            "Open context dialog to set up current project, task and folder."
+        )
         load_btn = QtWidgets.QPushButton("Load...", self)
         publish_btn = QtWidgets.QPushButton("Publish...", self)
         manage_btn = QtWidgets.QPushButton("Manage...", self)
@@ -30,6 +48,8 @@ class ToolsBtnsWidget(QtWidgets.QWidget):
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.context_btn, 0)
+        layout.addSpacing(4)
         layout.addWidget(load_btn, 0)
         layout.addWidget(manage_btn, 0)
         layout.addWidget(render_btn, 0)
@@ -44,6 +64,7 @@ class ToolsBtnsWidget(QtWidgets.QWidget):
         publish_btn.clicked.connect(self._on_publish)
         sequence_btn.clicked.connect(self._on_sequence)
         experimental_tools_btn.clicked.connect(self._on_experimental)
+        self.context_btn.clicked.connect(self._on_context_change)
 
     def _on_create(self):
         self.tool_required.emit("creator")
@@ -65,6 +86,29 @@ class ToolsBtnsWidget(QtWidgets.QWidget):
 
     def _on_experimental(self):
         self.tool_required.emit("experimental_tools")
+
+    def _on_context_change(self):
+        """Open a context dialog to change the current context."""
+        context = context_dialog.ask_for_context()
+
+        if context is None:
+            return
+
+        folder_entity = ayon_api.get_folder_by_id(
+            context["project_name"], folder_id=context["folder_id"])
+        task_entity = ayon_api.get_task_by_id(
+            context["project_name"], task_id=context["task_id"])
+        new_context = change_current_context(
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+        )
+
+        print(f"Context changed to: {new_context}")
+        WindowCache._first_show = True
+        self.context_btn.setText(
+            f"Context: {new_context['task_name']} - "
+            f"{new_context['folder_path']}"
+        )
 
 
 class ToolsDialog(QtWidgets.QDialog):

--- a/client/ayon_unreal/api/tools_ui.py
+++ b/client/ayon_unreal/api/tools_ui.py
@@ -20,6 +20,8 @@ from ayon_core.tools.utils.lib import qt_app_context
 from ayon_unreal.api import rendering
 from ayon_unreal.api import hierarchy
 
+import unreal
+
 
 class ToolsBtnsWidget(QtWidgets.QWidget):
     """Widget containing buttons which are clickable."""
@@ -103,8 +105,7 @@ class ToolsBtnsWidget(QtWidgets.QWidget):
             task_entity=task_entity,
         )
 
-        print(f"Context changed to: {new_context}")
-        WindowCache._first_show = True
+        unreal.log(f"Context changed to: {new_context}")
         self.context_btn.setText(
             f"Context: {new_context['task_name']} - "
             f"{new_context['folder_path']}"

--- a/server/settings.py
+++ b/server/settings.py
@@ -45,6 +45,13 @@ class ProjectSetup(BaseSettingsModel):
             "Disable when using external source control (Perforce)"
         )
     )
+    force_existing_project: bool = SettingsField(
+        True,
+        title="Force existing project",
+        description=(
+            "If enabled, the project must exist for Unreal to launch."
+        )
+    )
     dev_mode: bool = SettingsField(
         False,
         title="Dev mode"
@@ -87,7 +94,8 @@ DEFAULT_VALUES = {
         "render_format": "exr",
     },
     "project_setup": {
-        "dev_mode": False
+        "dev_mode": False,
+        "force_existing_project": False,
     },
     "create": DEFAULT_CREATOR_SETTINGS,
 }


### PR DESCRIPTION
## Changelog Description
Add change context dialog and allow Unreal Engine to run without pre-created project. This will allow to open/create projects via Unreal projects dialog and still use AYON tools from within Unreal.

## Additional review information
When the option to enable automatic project creation is disabled and Unreal cannot find existing project using resolved Anatomy template, this will run Unreal Editor without any project set. Unreal will popup the *"new project"* window where you can create new project based on templates or select existing project. When you then open existing one or create new one, Unreal Editor will restart and open selected project. There is now the option to see and change current context.

This feature is also adding new option to the project creation settings - *Force existing project*. When this option is enabled and automatic project creation is disabled and existing project isn't found, it will refuse to launch Unreal with error message.

> [!NOTE]
> When creating new Unreal project or opening existing one, make sure AYON integration plugin is enabled in Unreal on that project, else you won't see AYON tools menu.

Closes #231 

## Testing notes:
1. disable automatic project creation in Unreal Addon settings `ayon+settings://unreal/project_setup/allow_project_creation`
2. make sure `ayon+settings://unreal/project_setup/force_existing_project` is disabled too.
3. run Unreal on context where there is no existing unreal project
4. Unreal project window should pop-up. Either create new project or open existing one
5. Make sure AYON plugin is enabled on the project Unreal just opened.
6. In AYON tools, you should see first item in the list to be your current context. Clicking on it will present you with context selection dialog.
7. Select new context
8. You should see new context in AYON tools menu (and the Publisher should default to it also)
