### PR TITLE
Supports to use existing uproject for project creation

### DIFF
--- a/client/ayon_unreal/hooks/pre_workfile_preparation.py
+++ b/client/ayon_unreal/hooks/pre_workfile_preparation.py
@@ -295,7 +295,7 @@ class UnrealPrelaunchHook(PreLaunchHook):
                                                  unreal_project_name,
                                                  engine_path,
                                                  Path(temp_dir))
-                        self.copy_project(temp_dir, project_path)
+                        self.copy_project(Path(temp_dir), project_path)
 
             # if the template path has been found with unreal project
             # copy that existing project to ayon work directory
@@ -356,14 +356,15 @@ class UnrealPrelaunchHook(PreLaunchHook):
         """
         try:
             self.log.info((
-                f"Moving from {source} to "
+                f"Moving from {source.as_posix()} to "
                 f"{destination.as_posix()}"
             ))
             shutil.copytree(
                 source, destination, dirs_exist_ok=True)
 
         except shutil.Error as e:
-            raise ApplicationLaunchFailed((
-                f"{self.signature} Cannot copy directory {source} "
+            msg = (
+                f"{self.signature} Cannot copy directory {source.as_posix()} "
                 f"to {destination.as_posix()} - {e}"
-            )) from e
+            )
+            raise ApplicationLaunchFailed(msg) from e

--- a/client/ayon_unreal/hooks/pre_workfile_preparation.py
+++ b/client/ayon_unreal/hooks/pre_workfile_preparation.py
@@ -268,16 +268,15 @@ class UnrealPrelaunchHook(PreLaunchHook):
                     self.copy_project(existing_uproject_directory, project_path)
                     # rename the project folder and the uproject inside
                     # the project folder copied from existing_uproject directory
-                    new_project_name = unreal_project_filename
-                    project_path.rename(project_path.parent / new_project_name)
-                    for unproject_file in project_path.glob("*.uproject"):
+                    new_project_path = project_path.parent / unreal_project_name
+                    project_path.rename(new_project_path)
+                    for unproject_file in new_project_path.glob("*.uproject"):
                         # set the correct engine version
                         self.set_engine_version(unproject_file, engine_version)
-                        new_file_name = unreal_project_filename
-                        unproject_file.rename(project_path / new_file_name)
+                        unproject_file.rename(new_project_path / unreal_project_filename)
                         self.log.info((
                             f"{self.signature} Renamed {unproject_file.name} to "
-                            f"{new_file_name}"
+                            f"{unreal_project_filename}"
                         ))
                 else:
                     with tempfile.TemporaryDirectory() as temp_dir:

--- a/client/ayon_unreal/hooks/pre_workfile_preparation.py
+++ b/client/ayon_unreal/hooks/pre_workfile_preparation.py
@@ -267,25 +267,26 @@ class UnrealPrelaunchHook(PreLaunchHook):
                     uproject_files
                 ):
                     self.copy_project(existing_uproject_directory, project_path)
-                    # rename the project folder and the uproject inside
-                    # the project folder copied from existing_uproject directory
+                    # rename the project folder copied from existing_uproject directory
                     new_project_path = project_path.parent / unreal_project_name
                     project_path.rename(new_project_path)
 
-                    # make sure only one uproject file exists
-                    if len(uproject_files) != 1:
+                    # find the copied uproject file in the new project directory
+                    copied_uproject_files = list(new_project_path.glob("*.uproject"))
+                    if len(copied_uproject_files) != 1:
                         raise ApplicationLaunchFailed(
                             f"{self.signature} Expected exactly one .uproject file in "
-                            f"{new_project_path}, but found {len(uproject_files)}. "
+                            f"{new_project_path}, but found {len(copied_uproject_files)}. "
                             "Please check the project directory."
                         )
-                    unproject_file = uproject_files[0]
+                    copied_uproject_file = copied_uproject_files[0]
+                    # set the correct engine version on the copied file
+                    self.set_engine_version(copied_uproject_file, engine_version)
 
-                    # set the correct engine version
-                    self.set_engine_version(unproject_file, engine_version)
-                    unproject_file.rename(new_project_path / unreal_project_filename)
+                    # rename the copied uproject file to match the expected filename
+                    copied_uproject_file.rename(new_project_path / unreal_project_filename)
                     self.log.info((
-                        f"{self.signature} Renamed {unproject_file.name} to "
+                        f"{self.signature} Renamed {copied_uproject_file.name} to "
                         f"{unreal_project_filename}"
                     ))
                 else:

--- a/client/ayon_unreal/hooks/pre_workfile_preparation.py
+++ b/client/ayon_unreal/hooks/pre_workfile_preparation.py
@@ -271,6 +271,8 @@ class UnrealPrelaunchHook(PreLaunchHook):
                     # the project folder copied from existing_uproject directory
                     new_project_path = project_path.parent / unreal_project_name
                     project_path.rename(new_project_path)
+
+                    # make sure only one uproject file exists
                     if len(uproject_files) != 1:
                         raise ApplicationLaunchFailed(
                             f"{self.signature} Expected exactly one .uproject file in "
@@ -278,6 +280,7 @@ class UnrealPrelaunchHook(PreLaunchHook):
                             "Please check the project directory."
                         )
                     unproject_file = uproject_files[0]
+
                     # set the correct engine version
                     self.set_engine_version(unproject_file, engine_version)
                     unproject_file.rename(new_project_path / unreal_project_filename)

--- a/server/settings.py
+++ b/server/settings.py
@@ -45,6 +45,14 @@ class ProjectSetup(BaseSettingsModel):
             "Disable when using external source control (Perforce)"
         )
     )
+    existing_uproject_directory : str = SettingsField(
+        "",
+        title="Use Existing UProject for Project Creation",
+        description=(
+            "Path to an existing .uproject file to use for "
+            "project creation."
+        )
+    )
     force_existing_project: bool = SettingsField(
         True,
         title="Force existing project",
@@ -94,6 +102,8 @@ DEFAULT_VALUES = {
         "render_format": "exr",
     },
     "project_setup": {
+        "allow_project_creation": True,
+        "existing_uproject_directory": "",
         "dev_mode": False,
         "force_existing_project": False,
     },


### PR DESCRIPTION
## Changelog Description
This PR is to support users can put the directory of existing unreal project, they can migrate that project to the Ayon unreal-specific work directory and becomes the uproject which can be managed by Ayon
This needs to be used/valid along with `ayon+settings://unreal/project_setup/allow_project_creation` on

Resolve https://github.com/ynput/ayon-unreal/issues/240

## Additional review information
We should decide if this should be task-type based, which existing uproject is migrated based upon the task type.

## Testing notes:
1. Make sure you have existing uproject outside the Ayon directory.
2. Fill in the directory where you stored your uproject in `ayon+settings://unreal/project_setup/existing_uproject_directory`
<img width="1048" height="500" alt="image" src="https://github.com/user-attachments/assets/9325ea57-7f5a-4b79-b83e-1049cd166648" />

3. Launch Unreal with the task which does not have unreal project created.
4. Should be all working.