### PR TITLE
Asset name template for loaded assets

### DIFF
--- a/client/ayon_unreal/api/pipeline.py
+++ b/client/ayon_unreal/api/pipeline.py
@@ -899,11 +899,12 @@ def select_camera(sequence):
                 actor_subsys.set_actor_selection_state(actor, False)
 
 
-def format_asset_directory(context, directory_template):
+def format_asset_directory(context, directory_template, asset_name_template):
     """Setting up the asset directory path and name.
     Args:
         context (dict): context
         directory_template (str): directory template path
+        asset_name_template (str): asset name template
 
     Returns:
         tuple[str, str]: asset directory, asset name
@@ -939,36 +940,32 @@ def format_asset_directory(context, directory_template):
         data["version"]["version"] = "hero"
     else:
         data["version"]["version"] = f"v{version:03d}"
-    asset_name_with_version = set_asset_name(data)
+    asset_name_with_version = set_asset_name(data, asset_name_template)
     asset_dir = StringTemplate(directory_template).format_strict(data)
 
     return f"{AYON_ROOT_DIR}/{asset_dir}", asset_name_with_version
 
 
-def set_asset_name(data):
+def set_asset_name(data, asset_name_template):
     """Set the name of the asset during loading
 
     Args:
-        folder_name (str): folder name
-        name (str): instance name
-        extension (str): extension
+        data (dict): context data
+        asset_name_template (str): asset name template
 
     Returns:
         str: asset name
     """
-    asset_name = None,
-    name = data["product"]["name"]
-    version = data["version"]["version"]
     folder_name = data["folder"]["name"]
     extension = data["representation"]["name"]
     if not extension:
-        asset_name = name
-    elif folder_name:
-        asset_name = "{}_{}_{}_{}".format(
-            folder_name, name, version, extension)
-    else:
-        asset_name = "{}_{}_{}".format(name, version, extension)
-    return asset_name
+        asset_name_template = asset_name_template.replace(
+            "_{representation[name]}", "")
+    elif not folder_name:
+        asset_name_template = asset_name_template.replace(
+            "{folder[name]}_", "")
+
+    return StringTemplate(asset_name_template).format_strict(data)
 
 
 def show_audit_dialog(missing_asset):

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -22,6 +22,7 @@ class AnimationAlembicLoader(plugin.Loader):
     abc_conversion_preset = "maya"
     # check frame padding
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"      # noqa
     show_dialog = False
 
     @classmethod
@@ -31,6 +32,7 @@ class AnimationAlembicLoader(plugin.Loader):
         unreal_settings = project_settings["unreal"]["import_settings"]
         cls.abc_conversion_preset = unreal_settings["abc_conversion_preset"]
         cls.loaded_asset_dir = unreal_settings["loaded_asset_dir"]
+        cls.loaded_asset_name = unreal_settings["loaded_asset_name"]
         cls.show_dialog = unreal_settings["show_dialog"]
 
     @classmethod
@@ -198,14 +200,13 @@ class AnimationAlembicLoader(plugin.Loader):
         product_type = context["product"]["productType"]
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_root, asset_name = unreal_pipeline.format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
 
         container_name += suffix
 
@@ -268,7 +269,7 @@ class AnimationAlembicLoader(plugin.Loader):
         ext = os.path.splitext(source_path)[-1].lstrip(".")
 
         asset_root, asset_name = unreal_pipeline.format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         # do import fbx and replace existing data
         asset_tools = unreal.AssetToolsHelpers.get_asset_tools()

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -28,6 +28,7 @@ class AnimationFBXLoader(plugin.Loader):
 
     root = unreal_pipeline.AYON_ROOT_DIR
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"      # noqa
     show_dialog = False
 
     @classmethod
@@ -36,6 +37,7 @@ class AnimationFBXLoader(plugin.Loader):
         # Apply import settings
         unreal_settings = project_settings["unreal"]["import_settings"]
         cls.loaded_asset_dir = unreal_settings["loaded_asset_dir"]
+        cls.loaded_asset_name = unreal_settings["loaded_asset_name"]
         cls.show_dialog = unreal_settings["show_dialog"]
 
     def _import_latest_skeleton(self, version_ids):
@@ -445,14 +447,12 @@ class AnimationFBXLoader(plugin.Loader):
         suffix = "_CON"
 
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
-
         asset_root, asset_name = unreal_pipeline.format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
 
         container_name += suffix
         should_use_layout = options.get("layout", False)
@@ -512,13 +512,12 @@ class AnimationFBXLoader(plugin.Loader):
 
         suffix = "_CON"
         source_path = self.filepath_from_context(context)
-        ext = os.path.splitext(source_path)[-1].lstrip(".")
         asset_root, asset_name = unreal_pipeline.format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
 
         container_name += suffix
         should_use_layout = container.get("layout", False)

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -29,6 +29,7 @@ class CameraLoader(plugin.Loader):
     icon = "cube"
     color = "orange"
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"      # noqa
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -39,6 +40,11 @@ class CameraLoader(plugin.Loader):
             project_settings["unreal"]
                             ["import_settings"]
                             ["loaded_asset_dir"]
+        )
+        cls.loaded_asset_name = (
+            project_settings["unreal"]
+                            ["import_settings"]
+                            ["loaded_asset_name"]
         )
 
     def _import_camera(
@@ -186,7 +192,7 @@ class CameraLoader(plugin.Loader):
         folder_path = folder_entity["path"]
         folder_name = folder_entity["name"]
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir)
+            context, self.loaded_asset_dir, self.loaded_asset_name)
         master_dir_name = get_top_hierarchy_folder(asset_root)
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, hierarchy_dir, container_name, _ = (
@@ -237,7 +243,7 @@ class CameraLoader(plugin.Loader):
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir)
+            context, self.loaded_asset_dir, self.loaded_asset_name)
         master_dir_name = get_top_hierarchy_folder(asset_root)
         hierarchy_dir = f"{AYON_ROOT_DIR}/{master_dir_name}"
         suffix = "_CON"

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -28,6 +28,7 @@ class PointCacheAlembicLoader(plugin.Loader):
 
     abc_conversion_preset = "maya"
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"      # noqa
     show_dialog = False
 
     @classmethod
@@ -37,6 +38,7 @@ class PointCacheAlembicLoader(plugin.Loader):
         unreal_settings = project_settings["unreal"]["import_settings"]
         cls.abc_conversion_preset = unreal_settings["abc_conversion_preset"]
         cls.loaded_asset_dir = unreal_settings["loaded_asset_dir"]
+        cls.loaded_asset_name = unreal_settings["loaded_asset_name"]
         cls.show_dialog = unreal_settings["show_dialog"]
 
     @classmethod
@@ -211,14 +213,13 @@ class PointCacheAlembicLoader(plugin.Loader):
 
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
 
         frame_start = folder_attributes.get("frameStart")
         frame_end = folder_attributes.get("frameEnd")
@@ -277,15 +278,13 @@ class PointCacheAlembicLoader(plugin.Loader):
         asset_dir = container["namespace"]
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
 
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
-
+            asset_root, suffix="")
         frame_start = int(container.get("frame_start"))
         frame_end = int(container.get("frame_end"))
 

--- a/client/ayon_unreal/plugins/load/load_image_png.py
+++ b/client/ayon_unreal/plugins/load/load_image_png.py
@@ -25,6 +25,7 @@ class TexturePNGLoader(plugin.Loader):
     # Defined by settings
     show_dialog = False
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"      # noqa
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -33,6 +34,8 @@ class TexturePNGLoader(plugin.Loader):
         # Apply import settings
         import_settings = unreal_settings.get("import_settings", {})
         cls.show_dialog = import_settings.get("show_dialog", cls.show_dialog)
+        cls.loaded_asset_dir = import_settings.get("loaded_asset_dir", cls.loaded_asset_dir)
+        cls.loaded_asset_name = import_settings.get("loaded_asset_name", cls.loaded_asset_name)
 
     @classmethod
     def get_task(cls, filename, asset_dir, asset_name, replace):
@@ -129,13 +132,12 @@ class TexturePNGLoader(plugin.Loader):
         folder_path = context["folder"]["path"]
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
 
         container_name += suffix
 
@@ -165,18 +167,16 @@ class TexturePNGLoader(plugin.Loader):
         product_type = context["product"]["productType"]
         repre_entity = context["representation"]
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
 
         # Create directory for asset and Ayon container
         suffix = "_CON"
 
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir,
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
-
+            asset_root, suffix="")
         container_name += suffix
         asset_dir = self.import_and_containerize(
             path, asset_dir, container_name

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -28,6 +28,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
     abc_conversion_preset = "maya"
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"      # noqa
     show_dialog = False
 
     @classmethod
@@ -37,6 +38,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         unreal_settings = project_settings["unreal"]["import_settings"]
         cls.abc_conversion_preset = unreal_settings["abc_conversion_preset"]
         cls.loaded_asset_dir = unreal_settings["loaded_asset_dir"]
+        cls.loaded_asset_name = unreal_settings["loaded_asset_name"]
         cls.show_dialog = unreal_settings["show_dialog"]
 
     @classmethod
@@ -220,14 +222,13 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         folder_path = folder_entity["path"]
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
         container_name += suffix
 
         should_use_layout = options.get("layout", False)
@@ -283,15 +284,13 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         # Create directory for folder and Ayon container
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
 
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
-
+            asset_root, suffix="")
         container_name += suffix
         should_use_layout = container.get("layout", False)
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -23,6 +23,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
     color = "orange"
 
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"      # noqa
     show_dialog = False
 
     @classmethod
@@ -30,6 +31,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         unreal_settings = project_settings["unreal"]["import_settings"]
         super(SkeletalMeshFBXLoader, cls).apply_settings(project_settings)
         cls.loaded_asset_dir = unreal_settings["loaded_asset_dir"]
+        cls.loaded_asset_name = unreal_settings["loaded_asset_name"]
         cls.show_dialog = unreal_settings["show_dialog"]
 
     @classmethod
@@ -140,14 +142,13 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         product_type = context["product"]["productType"]
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
 
         container_name += suffix
         should_use_layout = options.get("layout", False)
@@ -191,14 +192,13 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         # Create directory for asset and Ayon container
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
 
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
 
         container_name += suffix
         should_use_layout = container.get("layout", False)

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -27,6 +27,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
     abc_conversion_preset = "maya"
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"      # noqa
     show_dialog = False
 
     @classmethod
@@ -36,6 +37,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
         unreal_settings = project_settings["unreal"]["import_settings"]
         cls.abc_conversion_preset = unreal_settings["abc_conversion_preset"]
         cls.loaded_asset_dir = unreal_settings["loaded_asset_dir"]
+        cls.loaded_asset_name = unreal_settings["loaded_asset_name"]
         cls.show_dialog = unreal_settings["show_dialog"]
 
     @classmethod
@@ -232,14 +234,12 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
-
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
 
         container_name += suffix
         should_use_layout = options.get("layout", False)
@@ -292,14 +292,12 @@ class StaticMeshAlembicLoader(plugin.Loader):
         # Create directory for asset and Ayon container
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
-
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
 
         container_name += suffix
         should_use_layout = container.get("layout", False)

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -26,6 +26,7 @@ class StaticMeshFBXLoader(plugin.Loader):
     use_nanite = True
     show_dialog = False
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"      # noqa
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -37,6 +38,8 @@ class StaticMeshFBXLoader(plugin.Loader):
         cls.use_nanite = import_settings.get("use_nanite", cls.use_nanite)
         cls.loaded_asset_dir = import_settings.get(
             "loaded_asset_dir", cls.loaded_asset_dir)
+        cls.loaded_asset_name = import_settings.get(
+            "loaded_asset_name", cls.loaded_asset_name)
 
     @classmethod
     def get_task(cls, filename, asset_dir, asset_name, replace):
@@ -138,14 +141,13 @@ class StaticMeshFBXLoader(plugin.Loader):
         folder_path = context["folder"]["path"]
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
         container_name += suffix
 
         should_use_layout = options.get("layout", False)
@@ -189,14 +191,12 @@ class StaticMeshFBXLoader(plugin.Loader):
         # Create directory for asset and Ayon container
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
-
         asset_root, asset_name = format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
 
         container_name += suffix
         should_use_layout = container.get("layout", False)

--- a/client/ayon_unreal/plugins/load/load_uasset.py
+++ b/client/ayon_unreal/plugins/load/load_uasset.py
@@ -42,6 +42,7 @@ class UAssetLoader(plugin.Loader):
     extension = "uasset"
 
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"       # noqa
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -71,7 +72,7 @@ class UAssetLoader(plugin.Loader):
         folder_path = context["folder"]["path"]
         suffix = "_CON"
         asset_root, asset_name = unreal_pipeline.format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(

--- a/client/ayon_unreal/plugins/load/load_yeticache.py
+++ b/client/ayon_unreal/plugins/load/load_yeticache.py
@@ -18,6 +18,7 @@ class YetiLoader(plugin.Loader):
     color = "orange"
 
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"
+    loaded_asset_name = "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}"      # noqa
 
     @classmethod
     def apply_settings(cls, project_settings):
@@ -25,6 +26,7 @@ class YetiLoader(plugin.Loader):
         # Apply import settings
         unreal_settings = project_settings["unreal"]["import_settings"]
         cls.loaded_asset_dir = unreal_settings["loaded_asset_dir"]
+        cls.loaded_asset_name = unreal_settings["loaded_asset_name"]
 
     @staticmethod
     def get_task(filename, asset_dir, asset_name, replace):
@@ -94,14 +96,13 @@ class YetiLoader(plugin.Loader):
         folder_path = context["folder"]["path"]
         suffix = "_CON"
         path = self.filepath_from_context(context)
-        ext = os.path.splitext(path)[-1].lstrip(".")
         asset_root, asset_name = unreal_pipeline.format_asset_directory(
-            context, self.loaded_asset_dir
+            context, self.loaded_asset_dir, self.loaded_asset_name
         )
 
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            asset_root, suffix=f"_{ext}")
+            asset_root, suffix="")
         container_name = f"{container_name}_{suffix}"
 
         should_use_layout = options.get("layout", False)

--- a/server/import_settings.py
+++ b/server/import_settings.py
@@ -44,6 +44,11 @@ class UnrealImportModel(BaseSettingsModel):
         description="Asset directories to store the loaded assets",
 
     )
+    loaded_asset_name: str = SettingsField(
+        "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}",
+        title="Asset name for loaded assets",
+        description="Asset name for the loaded assets",
+    )
     use_nanite: bool = SettingsField(True,
         title="Use nanite",
         description=(
@@ -105,6 +110,7 @@ class UnrealImportModel(BaseSettingsModel):
 
 DEFAULT_IMPORT_SETTINGS = {
     "loaded_asset_dir": "{folder[path]}/{product[name]}_{version[version]}",
+    "loaded_asset_name": "{folder[name]}_{product[name]}_{version[version]}_{representation[name]}",
     "asset_loading_location": "project",
     "use_nanite": True,
     "show_dialog": False,


### PR DESCRIPTION
## Changelog Description
This PR is to support the asset name template for loaded assets to allow users customizing their asset name by context data.

Resolve https://github.com/ynput/ayon-unreal/issues/220

## Additional review information
You need to build and install unreal addon with this branch

## Testing notes:
1. Build and install addon with this branch
2. Launch Unreal
3. Load anything
4. Everything should be working
