### PR TITLE
Use render presets on instance instead of settings values

### DIFF
--- a/client/ayon_unreal/api/rendering.py
+++ b/client/ayon_unreal/api/rendering.py
@@ -249,8 +249,6 @@ def start_rendering():
             job.map = unreal.SoftObjectPath(i["master_level"])
             job.author = "Ayon"
 
-
-
             job.set_configuration(config)
 
             # If we have a saved configuration, copy it to the job.

--- a/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
@@ -37,6 +37,7 @@ class CreateFarmRenderInstances(publish.AbstractCollectRender):
     order = pyblish.api.CollectorOrder + 0.21
     label = "Create Farm Render Instances"
     families = ["render"]
+    log = unreal.logger
 
     def preparing_rendering_instance(self, instance):
         context = instance.context
@@ -61,48 +62,51 @@ class CreateFarmRenderInstances(publish.AbstractCollectRender):
             subscenes = pipeline.get_subsequences(s.get('sequence'))
 
             if subscenes:
-                for ss in subscenes:
-                    sequences.append({
+                sequences.extend(
+                    {
                         "sequence": ss.get_sequence(),
-                        "output": (f"{s.get('output')}/"
-                                   f"{ss.get_sequence().get_name()}"),
+                        "output": (
+                            f"{s.get('output')}/" f"{ss.get_sequence().get_name()}"
+                        ),
                         "frame_range": (
-                            ss.get_start_frame(), ss.get_end_frame() - 1)
-                    })
-            else:
-                # Avoid creating instances for camera sequences
-                if "_camera" not in s.get('sequence').get_name():
-                    seq = s.get('sequence')
-                    seq_name = seq.get_name()
+                            ss.get_start_frame(),
+                            ss.get_end_frame() - 1,
+                        ),
+                    }
+                    for ss in subscenes
+                )
+            elif "_camera" not in s.get('sequence').get_name():
+                seq = s.get('sequence')
+                seq_name = seq.get_name()
 
-                    product_type = "render"
-                    new_product_name = f"{data.get('productName')}_{seq_name}"
-                    new_instance = context.create_instance(
-                        new_product_name
-                    )
-                    new_instance[:] = seq_name
+                new_product_name = f"{data.get('productName')}_{seq_name}"
+                new_instance = context.create_instance(
+                    new_product_name
+                )
+                new_instance[:] = seq_name
 
-                    new_data = new_instance.data
+                new_data = new_instance.data
 
-                    new_data["folderPath"] = instance.data["folderPath"]
-                    new_data["setMembers"] = seq_name
-                    new_data["productName"] = new_product_name
-                    new_data["productType"] = product_type
-                    new_data["family"] = product_type
-                    new_data["families"] = [product_type, "review"]
-                    new_data["parent"] = data.get("parent")
-                    new_data["level"] = data.get("level")
-                    new_data["output"] = s['output']
-                    new_data["fps"] = seq.get_display_rate().numerator
-                    new_data["frameStart"] = int(s.get('frame_range')[0])
-                    new_data["frameEnd"] = int(s.get('frame_range')[1])
-                    new_data["sequence"] = seq.get_path_name()
-                    new_data["master_sequence"] = data["master_sequence"]
-                    new_data["master_level"] = data["master_level"]
-                    new_data["review"] = instance.data.get("review", False)
-                    new_data["farm"] = instance.data.get("farm", False)
+                new_data["folderPath"] = instance.data["folderPath"]
+                new_data["setMembers"] = seq_name
+                new_data["productName"] = new_product_name
+                product_type = "render"
+                new_data["productType"] = product_type
+                new_data["family"] = product_type
+                new_data["families"] = [product_type, "review"]
+                new_data["parent"] = data.get("parent")
+                new_data["level"] = data.get("level")
+                new_data["output"] = s['output']
+                new_data["fps"] = seq.get_display_rate().numerator
+                new_data["frameStart"] = int(s.get('frame_range')[0])
+                new_data["frameEnd"] = int(s.get('frame_range')[1])
+                new_data["sequence"] = seq.get_path_name()
+                new_data["master_sequence"] = data["master_sequence"]
+                new_data["master_level"] = data["master_level"]
+                new_data["review"] = instance.data.get("review", False)
+                new_data["farm"] = instance.data.get("farm", False)
 
-                    self.log.debug(f"new instance data: {new_data}")
+                self.log.debug(f"new instance data: {new_data}")
 
     def get_instances(self, context):
         instances = []

--- a/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
@@ -118,30 +118,42 @@ class CreateFarmRenderInstances(publish.AbstractCollectRender):
         project_name = context.data["projectName"]
         project_settings = context.data['project_settings']
         render_settings = project_settings["unreal"]["render_setup"]
-        config_path, config = get_render_config(project_name, render_settings)
-        if not config:
-            raise RuntimeError("Please provide stored render config at path "
-                "set in `ayon+settings://unreal/render_setup/render_config_path`")
 
         output_ext_from_settings = render_settings["render_format"]
-        config = set_output_extension_from_settings(output_ext_from_settings,
-                                                    config)
-
-        ext = self._get_ext_from_config(config)
-        if not ext:
-            raise RuntimeError("Please provide output extension in config!")
-
-        output_settings = config.find_or_add_setting_by_class(
-            unreal.MoviePipelineOutputSetting)
-
-        resolution = output_settings.output_resolution
-        resolution_width = resolution.x
-        resolution_height = resolution.y
-
-        output_fps = output_settings.output_frame_rate
-        fps = f"{output_fps.denominator}.{output_fps.numerator}"
 
         for inst in context:
+            render_preset =inst.data.get("creator_attributes", {}).get(
+                "render_preset"
+            )
+            config_path, config = get_render_config(
+                project_name, render_preset, render_settings
+            )
+            if not config:
+                raise RuntimeError(
+                    "Please provide stored render config at path "
+                    "set in `ayon+settings://unreal/render_setup/render_config_path`"
+                )
+            config = set_output_extension_from_settings(
+                output_ext_from_settings, config
+            )
+
+            ext = self._get_ext_from_config(config)
+            if not ext:
+                raise RuntimeError(
+                    "Please provide output extension in config!"
+                )
+
+            output_settings = config.find_or_add_setting_by_class(
+                unreal.MoviePipelineOutputSetting
+            )
+
+            resolution = output_settings.output_resolution
+            resolution_width = resolution.x
+            resolution_height = resolution.y
+
+            output_fps = output_settings.output_frame_rate
+            fps = f"{output_fps.denominator}.{output_fps.numerator}"
+
             instance_families = inst.data.get("families", [])
             product_name = inst.data["productName"]
 

--- a/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
@@ -37,7 +37,7 @@ class CreateFarmRenderInstances(publish.AbstractCollectRender):
     order = pyblish.api.CollectorOrder + 0.21
     label = "Create Farm Render Instances"
     families = ["render"]
-    log = unreal.logger
+    log = unreal.log
 
     def preparing_rendering_instance(self, instance):
         context = instance.context


### PR DESCRIPTION
## Changelog Description
Select Movie Render Queue render configs on render instance creation. No need to set hardcoded paths in the Settings.

## Testing notes:
1. Save Render Presets to `/Game/Ayon`
2. When creating render instance, or editing it, you should be able to select them
