### PR TITLE
Getting valid project settings during project creation

### DIFF
--- a/client/ayon_unreal/lib.py
+++ b/client/ayon_unreal/lib.py
@@ -11,8 +11,8 @@ from distutils import dir_util
 from pathlib import Path
 from typing import List
 
-from ayon_core.pipeline.context_tools import get_current_project_settings
 from ayon_core.settings import get_project_settings
+from ayon_core.pipeline import get_current_project_name
 
 
 def get_engine_versions(env=None):
@@ -84,7 +84,8 @@ def get_editor_exe_path(engine_path: Path, engine_version: str) -> Path:
     this_os = platform.system().lower()
 
     try:
-        project_settings = get_current_project_settings()
+        project_name = get_current_project_name()
+        project_settings = get_project_settings(project_name)
         apps = project_settings["applications"]
         variants = apps["applications"]["unreal"]["variants"]
         platform_variants = [


### PR DESCRIPTION
## Changelog Description
This PR is to ensure the project settings should be gotten during project creation to avoid `current project is not set`.
Resolve https://github.com/ynput/ayon-unreal/issues/249

## Additional review information
n/a

## Testing notes:
1. Enable `ayon+settings://unreal/project_setup/allow_project_creation`
2. Launch Unreal with the task does not include/involve any unreal project
