### PR TITLE
Remove type hint argument from SettingFields to avoid initialisation quirk

### DIFF
--- a/server/creators.py
+++ b/server/creators.py
@@ -6,7 +6,7 @@ from ayon_server.settings import (
 
 
 class BasicCreatorModel(BaseSettingsModel):
-    enabled: bool = SettingsField(title="Enabled", type_hint=bool)
+    enabled: bool = SettingsField(title="Enabled")
     default_variants: list[str] = SettingsField(
         default_factory=list,
         description="Default variants used for constructing a product name",


### PR DESCRIPTION
## Changelog Description
This PR is to remove the additional type-hint argument from SettingFields to avoid initialisation quirk. 
`DEBUG   settings.settings_field    | Unsupported argument: type_hint at /addons/unreal/0.2.12/server/creators.py:9
`

## Additional review information
n/a

## Testing notes:
1. Build and install the addon from this branch
2. Restart the docker and see if the console for the server if the message `DEBUG   settings.settings_field    | Unsupported argument: type_hint at /addons/unreal/0.2.12/server/creators.py:9` still appears