### PR TITLE
Fix for deadline settings from unreal ayon to deadline

### DIFF
--- a/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
@@ -240,7 +240,7 @@ class CreateFarmRenderInstances(publish.AbstractCollectRender):
                 version,
             )
 
-            publish_attributes = {}
+            publish_attributes = inst.data.get("publish_attributes", {})
 
             try:
                 review = bool(inst.data["creator_attributes"].get("review"))


### PR DESCRIPTION
## Changelog Description
This fix allows to submit the settings to deadline from unreal, like pools, frames etc.
