### PR TITLE
Close the context dialog if no context is set

### DIFF
--- a/client/ayon_unreal/api/tools_ui.py
+++ b/client/ayon_unreal/api/tools_ui.py
@@ -91,10 +91,9 @@ class ToolsBtnsWidget(QtWidgets.QWidget):
 
     def _on_context_change(self):
         """Open a context dialog to change the current context."""
-        context = context_dialog.ask_for_context()
+        context = context_dialog.ask_for_context(strict=False)
 
         if context is None:
-            context_dialog.close()
             return
 
         folder_entity = ayon_api.get_folder_by_id(


### PR DESCRIPTION
## Changelog Description
This PR is to ensure the context dialog is closed correctly when users do not change the context through the context dialog in unreal
Resolve https://github.com/ynput/ayon-unreal/issues/258

## Additional review information
n/a

## Testing notes:
1. Launch Unreal
2. Click on the context in Ayon Menu
3. Dialog would be closed when context is/is not being set.
