### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_unreal/plugins/create/create_camera.py
+++ b/client/ayon_unreal/plugins/create/create_camera.py
@@ -14,6 +14,7 @@ class CreateCamera(UnrealAssetCreator):
     identifier = "io.ayon.creators.unreal.camera"
     label = "Camera"
     product_type = "camera"
+    product_base_type = "camera"
     icon = "fa.camera"
     default_variants = ["Main"]
 

--- a/client/ayon_unreal/plugins/create/create_layout.py
+++ b/client/ayon_unreal/plugins/create/create_layout.py
@@ -11,6 +11,7 @@ class CreateLayout(UnrealActorCreator):
     identifier = "io.ayon.creators.unreal.layout"
     label = "Layout"
     product_type = "layout"
+    product_base_type = "layout"
     icon = "cubes"
     default_variants = ["Main"]
 

--- a/client/ayon_unreal/plugins/create/create_render.py
+++ b/client/ayon_unreal/plugins/create/create_render.py
@@ -29,6 +29,7 @@ class CreateRender(UnrealAssetCreator):
     identifier = "io.ayon.creators.unreal.render"
     label = "Render"
     product_type = "render"
+    product_base_type = "render"
     icon = "eye"
     default_variants = ["Main"]
 

--- a/client/ayon_unreal/plugins/create/create_staticmeshfbx.py
+++ b/client/ayon_unreal/plugins/create/create_staticmeshfbx.py
@@ -10,5 +10,6 @@ class CreateStaticMeshFBX(UnrealAssetCreator):
     identifier = "io.ayon.creators.unreal.staticmeshfbx"
     label = "Static Mesh (FBX)"
     product_type = "staticMesh"
+    product_base_type = "staticMesh"
     icon = "cube"
     default_variants = ["Main"]

--- a/client/ayon_unreal/plugins/create/create_uasset.py
+++ b/client/ayon_unreal/plugins/create/create_uasset.py
@@ -15,6 +15,7 @@ class CreateUAsset(UnrealAssetCreator):
     identifier = "io.ayon.creators.unreal.uasset"
     label = "UAsset"
     product_type = "uasset"
+    product_base_type = "uasset"
     icon = "cube"
     default_variants = ["Main"]
 


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to existing creators. In this stage, it only mimics the product types. This has to be done in all DCC before further changes can be done in https://github.com/ynput/ayon-core to finalize the support.

## Additional review information
Additional PRs should check/address the usage of `product_type` as family - plugins shouldn't rely on having product type as family because if/when this is customized, workflow could stop work or behave unpredicable.

## Testing notes:
Everything should work as before.