### PR TITLE
propagate launch context environment to generate project ue workers

### DIFF
--- a/client/ayon_unreal/hooks/pre_workfile_preparation.py
+++ b/client/ayon_unreal/hooks/pre_workfile_preparation.py
@@ -130,7 +130,8 @@ class UnrealPrelaunchHook(PreLaunchHook):
             self.data["project_name"],
             unreal_project_name,
             engine_path,
-            project_dir
+            project_dir,
+            env=self.launch_context.env
         )
         ue_project_worker.moveToThread(q_thread)
         q_thread.started.connect(ue_project_worker.run)

--- a/client/ayon_unreal/ue_workers.py
+++ b/client/ayon_unreal/ue_workers.py
@@ -165,7 +165,10 @@ class UEProjectGenerationWorker(UEWorker):
             commandlet_cmd.append("-GenerateCode")
 
         gen_process = subprocess.Popen(
-            commandlet_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            commandlet_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env,
         )
 
         for line in gen_process.stdout:


### PR DESCRIPTION
## Changelog Description
When generating a project from scratch the creation fails as the Ayon unreal init attempts to import ayon_core.

## Additional review information
Need to investigate if this also needs UE_PYTHONPATH or not.

## Testing notes:
1. blank project one setup task
2. launch unreal for the first time on a the setup task
3. generation fails with no module found ayon_core
