### PR TITLE
change the method how to check for Pyside to be more pragmatic

### DIFF
--- a/client/ayon_unreal/hooks/pre_pyside_install.py
+++ b/client/ayon_unreal/hooks/pre_pyside_install.py
@@ -31,6 +31,11 @@ class InstallQtBinding(PreLaunchHook):
 
     def execute(self) -> None:
         """Entry point for the hook."""
+        if not self.data["project_settings"]["unreal"][
+            "prelaunch_settings"].get("enabled", True):
+            self.log.info("Skipping execution of %s.",
+                          self.__class__.__name__)
+            return
         try:
             self._execute()
         except Exception:  # noqa: BLE001
@@ -227,19 +232,22 @@ class InstallQtBinding(PreLaunchHook):
             "-c",
             f"import {pyside_name}",
         ]
+        kwargs = {}
+        if system().lower() == "windows":
+            kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
         returncode = subprocess.call(
             args,
             env=env,
             text=True,
-            creationflags=subprocess.CREATE_NO_WINDOW,
+            **kwargs,
         )
         if returncode == 0:
             self.log.debug(
                 "%s imported with unreal's python.", pyside_name
             )
             return True
-        self.log.error(
-            "Failed to import %s via subprocess.",
+        self.log.warning(
+            "Could not import %s, will attempt to install it.",
             pyside_name,
         )
         return False

--- a/client/ayon_unreal/hooks/pre_pyside_install.py
+++ b/client/ayon_unreal/hooks/pre_pyside_install.py
@@ -235,7 +235,7 @@ class InstallQtBinding(PreLaunchHook):
         )
         if returncode == 0:
             self.log.debug(
-                "%s imported with blender's python.", pyside_name
+                "%s imported with unreal's python.", pyside_name
             )
             return True
         self.log.error(

--- a/client/ayon_unreal/hooks/pre_pyside_install.py
+++ b/client/ayon_unreal/hooks/pre_pyside_install.py
@@ -223,30 +223,25 @@ class InstallQtBinding(PreLaunchHook):
                 env["PYTHONPATH"] = ue_pythonpath
 
         args = [
-            python_executable.as_posix(),
+            python_executable,
             "-c",
-            f"import {pyside_name}; print('{pyside_name} found')"
+            f"import {pyside_name}",
         ]
-
-        try:
-            process = subprocess.Popen(
-                args,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=env,
-                universal_newlines=True,
-                creationflags=subprocess.CREATE_NO_WINDOW,
+        returncode = subprocess.call(
+            args,
+            env=env,
+            text=True,
+            creationflags=subprocess.CREATE_NO_WINDOW,
+        )
+        if returncode == 0:
+            self.log.debug(
+                "%s imported with blender's python.", pyside_name
             )
-            stdout, _ = process.communicate()
-            if process.returncode == 0 and f"{pyside_name} found" in stdout:
-                self.log.debug(
-                    "%s found with unreal's python and UE_PYTHONPATH.",
-                    pyside_name)
-                return True
-        except Exception:
-            pass
-
-        self.log.error("Failed to import %s via subprocess.", pyside_name)
+            return True
+        self.log.error(
+            "Failed to import %s via subprocess.",
+            pyside_name,
+        )
         return False
 
     def find_parent_directory(self, file_path: str, target_dir="Binaries") -> str:

--- a/client/ayon_unreal/hooks/pre_pyside_install.py
+++ b/client/ayon_unreal/hooks/pre_pyside_install.py
@@ -197,9 +197,9 @@ class InstallQtBinding(PreLaunchHook):
         return_code = self.pip_install(args)
         return return_code
 
-    @staticmethod
-    def is_pyside_installed(python_executable: Path, pyside_name: str) -> bool:
-        """Check if PySide2/6 module is in unreal python env.
+    def is_pyside_installed(self, python_executable: Path,
+                            pyside_name: str) -> bool:
+        """Check if PySide2/6 module is importable with unreal's python.
 
         Args:
             python_executable (Path): Path to python executable.
@@ -207,27 +207,46 @@ class InstallQtBinding(PreLaunchHook):
                 and PySide6).
 
         Returns:
-            bool: True if PySide2 is installed, False otherwise.
+            bool: True if PySide2/6 is importable, False otherwise.
 
         """
-        # Get pip list from unreal's python executable
-        args = [python_executable.as_posix(), "-m", "pip", "list"]
-        process = subprocess.Popen(args, stdout=subprocess.PIPE)
-        stdout, _ = process.communicate()
-        lines = stdout.decode().split(os.linesep)
-        # Second line contain dashes that define maximum length of module name.
-        #   Second column of dashes define maximum length of module version.
-        package_dashes, *_ = lines[1].split(" ")
-        package_len = len(package_dashes)
+        env = self.launch_context.env.copy()
 
-        # Got through printed lines starting at line 3
-        for idx in range(2, len(lines)):
-            line = lines[idx]
-            if not line:
-                continue
-            package_name = line[:package_len].strip()
-            if package_name.lower() == pyside_name.lower():
+        # Add UE_PYTHONPATH to PYTHONPATH if it exists, as Unreal's python
+        # uses it
+        ue_pythonpath = env.get("UE_PYTHONPATH")
+        if ue_pythonpath:
+            pythonpath = env.get("PYTHONPATH", "")
+            if pythonpath:
+                env["PYTHONPATH"] = os.pathsep.join([pythonpath, ue_pythonpath])
+            else:
+                env["PYTHONPATH"] = ue_pythonpath
+
+        args = [
+            python_executable.as_posix(),
+            "-c",
+            f"import {pyside_name}; print('{pyside_name} found')"
+        ]
+
+        try:
+            process = subprocess.Popen(
+                args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                universal_newlines=True,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+            stdout, _ = process.communicate()
+            if process.returncode == 0 and f"{pyside_name} found" in stdout:
+                self.log.debug(
+                    "%s found with unreal's python and UE_PYTHONPATH.",
+                    pyside_name)
                 return True
+        except Exception:
+            pass
+
+        self.log.error("Failed to import %s via subprocess.", pyside_name)
         return False
 
     def find_parent_directory(self, file_path: str, target_dir="Binaries") -> str:

--- a/client/ayon_unreal/hooks/pre_pyside_install.py
+++ b/client/ayon_unreal/hooks/pre_pyside_install.py
@@ -33,7 +33,7 @@ class InstallQtBinding(PreLaunchHook):
         """Entry point for the hook."""
         if not self.data["project_settings"]["unreal"][
             "prelaunch_settings"].get("enabled", True):
-            self.log.info("Skipping execution of %s.",
+            self.log.debug("Skipping execution of %s.",
                           self.__class__.__name__)
             return
         try:

--- a/server/pre_launch_settings.py
+++ b/server/pre_launch_settings.py
@@ -2,8 +2,8 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
 class UnrealPreLaunchSetting(BaseSettingsModel):
-    """Install PySide2/6 Qt binding to unreal's python packages."""
-
+    """Install PySide2/6 Qt binding to unreal's python packages. Disable to bypass the hook."""
+    enabled: bool = SettingsField()
     use_dependency: bool = SettingsField(
         False,
         title="Use Offline Package Source",
@@ -33,6 +33,7 @@ class UnrealPreLaunchSetting(BaseSettingsModel):
 
 
 DEFAULT_PRELAUNCH_SETTINGS = {
+    "enabled": True,
     "use_dependency": False,
     "dependency_path": "",
     "arbitrary_site_package_location": False

--- a/server/pre_launch_settings.py
+++ b/server/pre_launch_settings.py
@@ -3,7 +3,7 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 
 class UnrealPreLaunchSetting(BaseSettingsModel):
     """Install PySide2/6 Qt binding to unreal's python packages. Disable to bypass the hook."""
-    enabled: bool = SettingsField()
+    enabled: bool = SettingsField(True, title="Enabled")
     use_dependency: bool = SettingsField(
         False,
         title="Use Offline Package Source",


### PR DESCRIPTION
Instead of pip list we test if we can import the binding and if yes we can proceed.
This enables workflows that take care of gathering dependencies beforehand like rez does.
The pip list method falls short as it focuses on the available packages inside blender, where rez obviously has no business.

Testing notes:
provide the CORRECT PySide binding before launching via Ayon egg via PYTHONPATH (these are many as since 6.3.x afaik they are all abi3 compat)
launch works without installing Pyside2/6
counter check
provide a wrong PySide version egg PySide 6.2.4 is afaik the last that is not abi3 compat for a wrong python version that does not match unreals
put that in PYTHONPATH
launch unreal
the import will fail and your hook will install the specified binding into blender