### PR TITLE
Loaders: Filters by extension instead of representation name

### DIFF
--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -16,7 +16,8 @@ class AnimationAlembicLoader(plugin.Loader):
 
     product_types = {"animation"}
     label = "Import Alembic Animation"
-    representations = {"abc"}
+    representations = {"*"}
+    extensions = {"abc"}
     icon = "cube"
     color = "orange"
     abc_conversion_preset = "maya"

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -22,7 +22,8 @@ class AnimationFBXLoader(plugin.Loader):
 
     product_types = {"animation"}
     label = "Import FBX Animation"
-    representations = {"fbx"}
+    representations = {"*"}
+    extensions = {"fbx"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -25,7 +25,8 @@ class CameraLoader(plugin.Loader):
 
     product_types = {"camera"}
     label = "Load Camera"
-    representations = {"fbx"}
+    representations = {"*"}
+    extensions = {"fbx"}
     icon = "cube"
     color = "orange"
     loaded_asset_dir = "{folder[path]}/{product[name]}_{version[version]}"

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -21,7 +21,8 @@ class PointCacheAlembicLoader(plugin.Loader):
 
     product_types = {"model", "pointcache"}
     label = "Import Alembic Point Cache"
-    representations = {"abc"}
+    representations = {"*"}
+    extensions = {"abc"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -21,7 +21,8 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
     product_types = {"pointcache", "skeletalMesh"}
     label = "Import Alembic Skeletal Mesh"
-    representations = {"abc"}
+    representations = {"*"}
+    extensions = {"abc"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -17,7 +17,8 @@ class SkeletalMeshFBXLoader(plugin.Loader):
 
     product_types = {"rig", "skeletalMesh"}
     label = "Import FBX Skeletal Mesh"
-    representations = {"fbx"}
+    representations = {"*"}
+    extensions = {"fbx"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -20,7 +20,8 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
     product_types = {"model", "staticMesh"}
     label = "Import Alembic Static Mesh"
-    representations = {"abc"}
+    representations = {"*"}
+    extensions = {"abc"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -18,7 +18,8 @@ class StaticMeshFBXLoader(plugin.Loader):
 
     product_types = {"model", "staticMesh"}
     label = "Import FBX Static Mesh"
-    representations = {"fbx"}
+    representations = {"*"}
+    extensions = {"fbx"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_unreal/plugins/load/load_uasset.py
+++ b/client/ayon_unreal/plugins/load/load_uasset.py
@@ -35,7 +35,8 @@ class UAssetLoader(plugin.Loader):
 
     product_types = {"uasset"}
     label = "Load UAsset"
-    representations = {"uasset"}
+    representations = {"*"}
+    extensions = {"uasset"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_unreal/plugins/load/load_yeticache.py
+++ b/client/ayon_unreal/plugins/load/load_yeticache.py
@@ -13,7 +13,8 @@ class YetiLoader(plugin.Loader):
 
     product_types = {"yeticacheUE"}
     label = "Import Yeti"
-    representations = {"abc"}
+    representations = {"*"}
+    extensions = {"abc"}
     icon = "pagelines"
     color = "orange"
 


### PR DESCRIPTION
## Changelog Description

Loaders: Filters by extension instead of representation name

## Additional review information

Make loaders filter by extension instead of representation name so they are less restrictive on what can be loaded.

## Testing notes:

1. Validate code changes
2. Loaders should still be able to load the right representations, etc.