### PR TITLE
🏛️Product base types: Product types and base types (Phase 1)

### DIFF
--- a/client/ayon_unreal/api/plugin.py
+++ b/client/ayon_unreal/api/plugin.py
@@ -63,6 +63,7 @@ class UnrealCreateLogic():
                 if creator_id:
                     unreal_cached_subsets[creator_id].append(instance)
                 else:
+                    # Backwards compatibility for older instances
                     product_type = instance.get("product_type")
                     unreal_cached_legacy_subsets[product_type].append(instance)
 
@@ -125,12 +126,24 @@ class UnrealCreateLogic():
 
             instance_data["product_name"] = product_name
             instance_data["instance_path"] = f"{self.root}/{instance_name}"
+            product_type = instance_data.get("productType")
+            if not product_type:
+                product_type = self.product_base_type
+            product_type_kwargs = {
+                "product_base_type": self.product_base_type,
+                "product_type": product_type,
+            }
+            if not hasattr(CreatedInstance, "product_base_type"):
+                product_type_kwargs["product_type"] = product_type_kwargs.pop(
+                    "product_base_type"
+                )
 
             instance = CreatedInstance(
-                self.product_type,
-                product_name,
-                instance_data,
-                self)
+                **product_type_kwargs,
+                product_name=product_name,
+                data=instance_data,
+                creator=self,
+            )
             self._add_instance_to_context(instance)
 
             pub_instance.set_editor_property('add_external_assets', True)

--- a/client/ayon_unreal/api/plugin.py
+++ b/client/ayon_unreal/api/plugin.py
@@ -294,7 +294,8 @@ class Loader(LoaderPlugin, ABC):
 class LayoutLoader(Loader):
     """Load Layout from a JSON file"""
 
-    product_types = {"layout"}
+    product_base_types = {"layout"}
+    product_types = product_base_types
     representations = {"json"}
 
     label = "Load Layout"
@@ -305,13 +306,13 @@ class LayoutLoader(Loader):
     remove_loaded_assets = False
 
     @staticmethod
-    def _get_fbx_loader(loaders, family):
+    def _get_fbx_loader(loaders, product_base_type):
         name = ""
-        if family in ['rig', 'skeletalMesh']:
+        if product_base_type in ['rig', 'skeletalMesh']:
             name = "SkeletalMeshFBXLoader"
-        elif family in ['model', 'staticMesh']:
+        elif product_base_type in ['model', 'staticMesh']:
             name = "StaticMeshFBXLoader"
-        elif family == 'camera':
+        elif product_base_type == 'camera':
             name = "CameraLoader"
 
         if name == "":
@@ -325,13 +326,13 @@ class LayoutLoader(Loader):
         return None
 
     @staticmethod
-    def _get_abc_loader(loaders, family):
+    def _get_abc_loader(loaders, product_base_type):
         name = ""
-        if family in ['rig', 'skeletalMesh']:
+        if product_base_type in ['rig', 'skeletalMesh']:
             name = "SkeletalMeshAlembicLoader"
-        elif family in ['model', 'staticMesh']:
+        elif product_base_type in ['model', 'staticMesh']:
             name = "StaticMeshAlembicLoader"
-        elif family in ["animation"]:
+        elif product_base_type in ["animation"]:
             name = "AnimationAlembicLoader"
         if name == "":
             return None
@@ -419,10 +420,13 @@ class LayoutLoader(Loader):
         project_name,
         hierarchy_dir=None
     ):
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
         data = {
             "schema": "ayon:container-2.0",
             "id": AYON_CONTAINER_ID,
-            "asset": folder_name,
             "folder_path": folder_path,
             "namespace": asset_dir,
             "container_name": container_name,
@@ -430,16 +434,21 @@ class LayoutLoader(Loader):
             "loader": str(self.__class__.__name__),
             "representation": context["representation"]["id"],
             "parent": context["representation"]["versionId"],
-            "family": context["product"]["productType"],
+            "product_base_type": product_base_type,
             "loaded_assets": loaded_assets,
-            "project_name": project_name
+            "project_name": project_name,
+            # TODO remove deprecated keys
+            "asset": folder_name,
+            "family": product_base_type,
         }
         if hierarchy_dir is not None:
             data["master_directory"] = hierarchy_dir
         imprint(
             "{}/{}".format(asset_dir, container_name), data)
 
-    def _load_assets(self, instance_name, repre_id, product_type, repr_format):
+    def _load_assets(
+        self, instance_name, repre_id, product_base_type, repr_format
+    ):
         all_loaders = discover_loader_plugins()
         loaders = loaders_from_representation(
             all_loaders, repre_id)
@@ -447,22 +456,23 @@ class LayoutLoader(Loader):
         loader = None
 
         if repr_format == 'fbx':
-            loader = self._get_fbx_loader(loaders, product_type)
+            loader = self._get_fbx_loader(loaders, product_base_type)
         elif repr_format == 'abc':
-            loader = self._get_abc_loader(loaders, product_type)
+            loader = self._get_abc_loader(loaders, product_base_type)
 
         if not loader:
             if repr_format == "ma":
                 msg = (
-                    f"No valid {product_type} loader found for {repre_id} ({repr_format}), "
-                    f"consider using {product_type} loader (fbx/abc) instead."
+                    f"No valid {product_base_type} loader found"
+                    f" for {repre_id} ({repr_format}), consider using"
+                    f" {product_base_type} loader (fbx/abc) instead."
                 )
                 self.log.warning(msg)
             else:
                 self.log.error(
                     f"No valid loader found for {repre_id} "
-                    f"({repr_format}) "
-                    f"{product_type}")
+                    f"({repr_format}) {product_base_type}"
+                )
             return
 
         import_options = {

--- a/client/ayon_unreal/api/rendering.py
+++ b/client/ayon_unreal/api/rendering.py
@@ -169,7 +169,10 @@ def start_rendering():
 
     for i in instances:
         data = pipeline.parse_container(i.get_path_name())
-        if data["productType"] == "render":
+        product_base_type = data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = data["productType"]
+        if product_base_type == "render":
             inst_data.append(data)
 
     try:

--- a/client/ayon_unreal/plugins/create/create_camera.py
+++ b/client/ayon_unreal/plugins/create/create_camera.py
@@ -13,8 +13,8 @@ class CreateCamera(UnrealAssetCreator):
 
     identifier = "io.ayon.creators.unreal.camera"
     label = "Camera"
-    product_type = "camera"
     product_base_type = "camera"
+    product_type = product_base_type
     icon = "fa.camera"
     default_variants = ["Main"]
 

--- a/client/ayon_unreal/plugins/create/create_layout.py
+++ b/client/ayon_unreal/plugins/create/create_layout.py
@@ -10,8 +10,8 @@ class CreateLayout(UnrealActorCreator):
 
     identifier = "io.ayon.creators.unreal.layout"
     label = "Layout"
-    product_type = "layout"
     product_base_type = "layout"
+    product_type = product_base_type
     icon = "cubes"
     default_variants = ["Main"]
 

--- a/client/ayon_unreal/plugins/create/create_render.py
+++ b/client/ayon_unreal/plugins/create/create_render.py
@@ -28,8 +28,8 @@ class CreateRender(UnrealAssetCreator):
 
     identifier = "io.ayon.creators.unreal.render"
     label = "Render"
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     icon = "eye"
     default_variants = ["Main"]
 

--- a/client/ayon_unreal/plugins/create/create_staticmeshfbx.py
+++ b/client/ayon_unreal/plugins/create/create_staticmeshfbx.py
@@ -9,7 +9,7 @@ class CreateStaticMeshFBX(UnrealAssetCreator):
 
     identifier = "io.ayon.creators.unreal.staticmeshfbx"
     label = "Static Mesh (FBX)"
-    product_type = "staticMesh"
     product_base_type = "staticMesh"
+    product_type = product_base_type
     icon = "cube"
     default_variants = ["Main"]

--- a/client/ayon_unreal/plugins/create/create_uasset.py
+++ b/client/ayon_unreal/plugins/create/create_uasset.py
@@ -14,8 +14,8 @@ class CreateUAsset(UnrealAssetCreator):
 
     identifier = "io.ayon.creators.unreal.uasset"
     label = "UAsset"
-    product_type = "uasset"
     product_base_type = "uasset"
+    product_type = product_base_type
     icon = "cube"
     default_variants = ["Main"]
 
@@ -56,7 +56,8 @@ class CreateUMap(CreateUAsset):
 
     identifier = "io.ayon.creators.unreal.umap"
     label = "Level"
-    product_type = "uasset"
+    product_base_type = "uasset"
+    product_type = product_base_type
     extension = ".umap"
 
     def create(self, product_name, instance_data, pre_create_data):

--- a/client/ayon_unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_unreal/plugins/load/load_alembic_animation.py
@@ -14,7 +14,8 @@ import unreal  # noqa
 class AnimationAlembicLoader(plugin.Loader):
     """Load Unreal SkeletalMesh from Alembic"""
 
-    product_types = {"animation"}
+    product_base_types = {"animation"}
+    product_types = product_base_types
     label = "Import Alembic Animation"
     representations = {"*"}
     extensions = {"abc"}
@@ -197,10 +198,14 @@ class AnimationAlembicLoader(plugin.Loader):
 
         # Create directory for asset and ayon container
         folder_entity = context["folder"]
-        folder_path = context["folder"]["path"]
-        product_type = context["product"]["productType"]
+        folder_path = folder_entity["path"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
+
         suffix = "_CON"
-        path = self.filepath_from_context(context)
         asset_root, asset_name = unreal_pipeline.format_asset_directory(
             context, self.loaded_asset_dir, self.loaded_asset_name
         )
@@ -244,7 +249,7 @@ class AnimationAlembicLoader(plugin.Loader):
             folder_entity["attrib"]["frameStart"],
             folder_entity["attrib"]["frameEnd"],
             context["representation"],
-            product_type,
+            product_base_type,
             context["project"]["name"],
             should_use_layout
         )
@@ -260,8 +265,12 @@ class AnimationAlembicLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_type = context["product"]["productType"]
         repre_entity = context["representation"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
 
         # Create directory for folder and Ayon container
         suffix = "_CON"
@@ -310,7 +319,7 @@ class AnimationAlembicLoader(plugin.Loader):
             container.get("frameStart", "1"),
             container.get("frameEnd", "1"),
             repre_entity,
-            product_type,
+            product_base_type,
             context["project"]["name"],
             should_use_layout
         )

--- a/client/ayon_unreal/plugins/load/load_animation.py
+++ b/client/ayon_unreal/plugins/load/load_animation.py
@@ -20,7 +20,8 @@ from unreal import (EditorAssetLibrary, MovieSceneSkeletalAnimationSection,
 class AnimationFBXLoader(plugin.Loader):
     """Load Unreal SkeletalMesh from FBX."""
 
-    product_types = {"animation"}
+    product_base_types = {"animation"}
+    product_types = product_base_types
     label = "Import FBX Animation"
     representations = {"*"}
     extensions = {"fbx"}
@@ -443,7 +444,11 @@ class AnimationFBXLoader(plugin.Loader):
         folder_path = folder_entity["path"]
         hierarchy = folder_path.lstrip("/").split("/")
         folder_name = hierarchy.pop(-1)
-        product_type = context["product"]["productType"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
 
         suffix = "_CON"
 
@@ -478,7 +483,7 @@ class AnimationFBXLoader(plugin.Loader):
             container_name,
             asset_name,
             context["representation"],
-            product_type,
+            product_base_type,
             folder_entity,
             context["project"]["name"],
             should_use_layout
@@ -503,13 +508,16 @@ class AnimationFBXLoader(plugin.Loader):
 
     def update(self, container, context):
         # Create directory for folder and Ayon container
-        folder_path = context["folder"]["path"]
+        folder_entity = context["folder"]
+        folder_path = folder_entity["path"]
         hierarchy = folder_path.lstrip("/").split("/")
         folder_name = hierarchy.pop(-1)
-        folder_name = context["folder"]["name"]
-        product_type = context["product"]["productType"]
+
         repre_entity = context["representation"]
-        folder_entity = context["folder"]
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
 
         suffix = "_CON"
         source_path = self.filepath_from_context(context)
@@ -546,7 +554,7 @@ class AnimationFBXLoader(plugin.Loader):
             container_name,
             asset_name,
             repre_entity,
-            product_type,
+            product_base_type,
             folder_entity,
             context["project"]["name"],
             should_use_layout

--- a/client/ayon_unreal/plugins/load/load_camera.py
+++ b/client/ayon_unreal/plugins/load/load_camera.py
@@ -23,7 +23,8 @@ from ayon_unreal.api.pipeline import (
 class CameraLoader(plugin.Loader):
     """Load Unreal StaticMesh from FBX"""
 
-    product_types = {"camera"}
+    product_base_types = {"camera"}
+    product_types = product_base_types
     label = "Load Camera"
     representations = {"*"}
     extensions = {"fbx"}
@@ -83,7 +84,7 @@ class CameraLoader(plugin.Loader):
         asset_name,
         representation,
         folder_name,
-        product_type,
+        product_base_type,
         folder_entity,
         project_name
     ):
@@ -97,10 +98,11 @@ class CameraLoader(plugin.Loader):
             "loader": str(self.__class__.__name__),
             "representation": representation["id"],
             "parent": representation["versionId"],
-            "product_type": product_type,
+            "product_base_type": product_base_type,
             # TODO these should be probably removed
             "asset": folder_name,
-            "family": product_type,
+            "product_type": product_base_type,
+            "family": product_base_type,
             "frameStart": folder_entity["attrib"]["frameStart"],
             "frameEnd": folder_entity["attrib"]["frameEnd"],
             "project_name": project_name
@@ -192,6 +194,12 @@ class CameraLoader(plugin.Loader):
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
         folder_name = folder_entity["name"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
+
         asset_root, asset_name = format_asset_directory(
             context, self.loaded_asset_dir, self.loaded_asset_name)
         master_dir_name = get_top_hierarchy_folder(asset_root)
@@ -221,7 +229,7 @@ class CameraLoader(plugin.Loader):
             asset_name,
             context["representation"],
             folder_name,
-            context["product"]["productType"],
+            product_base_type,
             folder_entity,
             context["project"]["name"]
         )
@@ -243,6 +251,12 @@ class CameraLoader(plugin.Loader):
         # Create directory for asset and Ayon container
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
+
         asset_root, asset_name = format_asset_directory(
             context, self.loaded_asset_dir, self.loaded_asset_name)
         master_dir_name = get_top_hierarchy_folder(asset_root)
@@ -276,7 +290,7 @@ class CameraLoader(plugin.Loader):
             asset_name,
             context["representation"],
             folder_entity["name"],
-            context["product"]["productType"],
+            product_base_type,
             folder_entity,
             context["project"]["name"]
         )

--- a/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_unreal/plugins/load/load_geometrycache_abc.py
@@ -19,7 +19,8 @@ import unreal  # noqa
 class PointCacheAlembicLoader(plugin.Loader):
     """Load Point Cache from Alembic"""
 
-    product_types = {"model", "pointcache"}
+    product_base_types = {"model", "pointcache"}
+    product_types = product_base_types
     label = "Import Alembic Point Cache"
     representations = {"*"}
     extensions = {"abc"}
@@ -166,7 +167,7 @@ class PointCacheAlembicLoader(plugin.Loader):
         representation,
         frame_start,
         frame_end,
-        product_type,
+        product_base_type,
         project_name,
         layout
     ):
@@ -181,10 +182,11 @@ class PointCacheAlembicLoader(plugin.Loader):
             "parent": representation["versionId"],
             "frame_start": frame_start,
             "frame_end": frame_end,
-            "product_type": product_type,
+            "product_base_type": product_base_type,
             "folder_path": folder_path,
             # TODO these should be probably removed
-            "family": product_type,
+            "product_type": product_base_type,
+            "family": product_base_type,
             "asset": folder_path,
             "project_name": project_name,
             "layout": layout
@@ -210,6 +212,11 @@ class PointCacheAlembicLoader(plugin.Loader):
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
         folder_attributes = folder_entity["attrib"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
 
         suffix = "_CON"
         path = self.filepath_from_context(context)
@@ -257,7 +264,7 @@ class PointCacheAlembicLoader(plugin.Loader):
             context["representation"],
             frame_start,
             frame_end,
-            context["product"]["productType"],
+            product_base_type,
             context["project"]["name"],
             should_use_layout
         )
@@ -273,7 +280,10 @@ class PointCacheAlembicLoader(plugin.Loader):
     def update(self, container, context):
         # Create directory for folder and Ayon container
         folder_path = context["folder"]["path"]
-        product_type = context["product"]["productType"]
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
         repre_entity = context["representation"]
         asset_dir = container["namespace"]
         suffix = "_CON"
@@ -314,7 +324,7 @@ class PointCacheAlembicLoader(plugin.Loader):
             repre_entity,
             frame_start,
             frame_end,
-            product_type,
+            product_base_type,
             context["project"]["name"],
             should_use_layout
         )

--- a/client/ayon_unreal/plugins/load/load_image_png.py
+++ b/client/ayon_unreal/plugins/load/load_image_png.py
@@ -14,7 +14,8 @@ import unreal  # noqa
 class TexturePNGLoader(plugin.Loader):
     """Load Unreal texture from PNG file."""
 
-    product_types = {"image", "texture", "render"}
+    product_base_types = {"image", "texture", "render"}
+    product_types = product_base_types
     label = "Import image texture 2d"
     representations = {"*"}
     extensions = {"png", "jpg", "tiff", "exr"}
@@ -91,7 +92,7 @@ class TexturePNGLoader(plugin.Loader):
         container_name,
         asset_name,
         repre_entity,
-        product_type,
+        product_base_type,
         project_name
     ):
         data = {
@@ -104,10 +105,11 @@ class TexturePNGLoader(plugin.Loader):
             "loader": str(self.__class__.__name__),
             "representation": repre_entity["id"],
             "parent": repre_entity["versionId"],
-            "product_type": product_type,
+            "product_base_type": product_base_type,
             # TODO these shold be probably removed
             "asset": folder_path,
-            "family": product_type,
+            "product_type": product_base_type,
+            "family": product_base_type,
             "project_name": project_name
         }
         imprint(f"{asset_dir}/{container_name}", data)
@@ -129,6 +131,12 @@ class TexturePNGLoader(plugin.Loader):
         """
         # Create directory for asset and Ayon container
         folder_path = context["folder"]["path"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
+
         suffix = "_CON"
         path = self.filepath_from_context(context)
         asset_root, asset_name = format_asset_directory(
@@ -149,7 +157,7 @@ class TexturePNGLoader(plugin.Loader):
             container_name,
             asset_name,
             context["representation"],
-            context["product"]["productType"],
+            product_base_type,
             context["project"]["name"],
         )
 
@@ -163,7 +171,10 @@ class TexturePNGLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_type = context["product"]["productType"]
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
         repre_entity = context["representation"]
         path = self.filepath_from_context(context)
 
@@ -187,7 +198,7 @@ class TexturePNGLoader(plugin.Loader):
             container_name,
             asset_name,
             repre_entity,
-            product_type,
+            product_base_type,
             context["project"]["name"]
         )
 

--- a/client/ayon_unreal/plugins/load/load_layout.py
+++ b/client/ayon_unreal/plugins/load/load_layout.py
@@ -180,12 +180,14 @@ class LayoutLoader(plugin.LayoutLoader):
             if repre_id not in repr_loaded:
                 repr_loaded.append(repre_id)
 
-                product_type = element.get("product_type")
-                if product_type is None:
-                    product_type = element.get("family")
+                product_base_type = element.get("product_base_type")
+                if not product_base_type:
+                    product_base_type = element.get("product_type")
+                    if product_base_type is None:
+                        product_base_type = element.get("family")
 
                 assets = self._load_assets(
-                    instance_name, repre_id, product_type, repr_format
+                    instance_name, repre_id, product_base_type, repr_format
                 )
 
                 container = None
@@ -216,12 +218,12 @@ class LayoutLoader(plugin.LayoutLoader):
 
                     actors = []
 
-                    if product_type in ['model', 'staticMesh']:
+                    if product_base_type in ['model', 'staticMesh']:
                         actors, _ = self._process_family(
                             assets, 'StaticMesh', transform, basis,
                             sequence, rotation, unreal_import=unreal_import
                         )
-                    elif product_type in ['rig', 'skeletalMesh']:
+                    elif product_base_type in ['rig', 'skeletalMesh']:
                         actors, bindings = self._process_family(
                             assets, 'SkeletalMesh', transform, basis,
                             sequence, rotation, unreal_import=unreal_import

--- a/client/ayon_unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_unreal/plugins/load/load_layout_existing.py
@@ -59,7 +59,9 @@ class ExistingLayoutLoader(plugin.LayoutLoader):
                 "Skipping to add spawned actor into the sequence."
             )
 
-    def _load_asset(self, repr_data, instance_name, family, extension):
+    def _load_asset(
+        self, repr_data, instance_name, product_base_type, extension
+    ):
         repre_entity = next((repre_entity for repre_entity in repr_data
                              if repre_entity["name"] == extension), None)
         if not repre_entity or extension == "ma":
@@ -68,7 +70,7 @@ class ExistingLayoutLoader(plugin.LayoutLoader):
         repr_format = repre_entity.get('name')
         representation = repre_entity.get('id')
         assets = self._load_assets(
-            instance_name, representation, family, repr_format
+            instance_name, representation, product_base_type, repr_format
         )
         return assets
 
@@ -223,14 +225,16 @@ class ExistingLayoutLoader(plugin.LayoutLoader):
                     f" {version_id}")
                 continue
 
-            product_type = lasset.get("product_type")
-            if product_type is None:
-                product_type = lasset.get("family")
+            product_base_type = lasset.get("product_base_type")
+            if not product_base_type:
+                product_base_type = lasset.get("product_type")
+                if product_base_type is None:
+                    product_base_type = lasset.get("family")
             extension = lasset.get("extension")
             assets = self._load_asset(
                 repre_entities,
                 lasset.get('instance_name'),
-                product_type,
+                product_base_type,
                 extension
             )
             con = None

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_abc.py
@@ -19,7 +19,8 @@ import unreal  # noqa
 class SkeletalMeshAlembicLoader(plugin.Loader):
     """Load Unreal SkeletalMesh from Alembic"""
 
-    product_types = {"pointcache", "skeletalMesh"}
+    product_base_types = {"pointcache", "skeletalMesh"}
+    product_types = product_base_types
     label = "Import Alembic Skeletal Mesh"
     representations = {"*"}
     extensions = {"abc"}
@@ -220,6 +221,12 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
         # Create directory for asset and ayon container
         folder_entity = context["folder"]
         folder_path = folder_entity["path"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
+
         suffix = "_CON"
         path = self.filepath_from_context(context)
         asset_root, asset_name = format_asset_directory(
@@ -260,7 +267,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             container_name,
             asset_name,
             context["representation"],
-            context["product"]["productType"],
+            product_base_type,
             folder_entity["attrib"]["frameStart"],
             folder_entity["attrib"]["frameEnd"],
             context["project"]["name"],
@@ -278,7 +285,11 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_type = context["product"]["productType"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
         repre_entity = context["representation"]
 
         # Create directory for folder and Ayon container
@@ -318,7 +329,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
             container_name,
             asset_name,
             repre_entity,
-            product_type,
+            product_base_type,
             container.get("frameStart", 1),
             container.get("frameEnd", 1),
             context["project"]["name"],

--- a/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -15,7 +15,8 @@ import unreal  # noqa
 class SkeletalMeshFBXLoader(plugin.Loader):
     """Load Unreal SkeletalMesh from FBX."""
 
-    product_types = {"rig", "skeletalMesh"}
+    product_base_types = {"rig", "skeletalMesh"}
+    product_types = product_base_types
     label = "Import FBX Skeletal Mesh"
     representations = {"*"}
     extensions = {"fbx"}
@@ -99,7 +100,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         container_name,
         asset_name,
         representation,
-        product_type,
+        product_base_type,
         project_name,
         layout
     ):
@@ -113,10 +114,11 @@ class SkeletalMeshFBXLoader(plugin.Loader):
             "loader": str(self.__class__.__name__),
             "representation": representation["id"],
             "parent": representation["versionId"],
-            "product_type": product_type,
+            "product_base_type": product_base_type,
             # TODO these should be probably removed
             "asset": folder_path,
-            "family": product_type,
+            "product_type": product_base_type,
+            "family": product_base_type,
             "project_name": project_name,
             "layout": layout
         }
@@ -139,7 +141,12 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         """
         # Create directory for asset and Ayon container
         folder_name = context["folder"]["name"]
-        product_type = context["product"]["productType"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
+
         suffix = "_CON"
         path = self.filepath_from_context(context)
         asset_root, asset_name = format_asset_directory(
@@ -170,7 +177,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
             container_name,
             asset_name,
             context["representation"],
-            product_type,
+            product_base_type,
             context["project"]["name"],
             should_use_layout
         )
@@ -186,7 +193,11 @@ class SkeletalMeshFBXLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_type = context["product"]["productType"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
         repre_entity = context["representation"]
 
         # Create directory for asset and Ayon container
@@ -220,7 +231,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
             container_name,
             asset_name,
             repre_entity,
-            product_type,
+            product_base_type,
             context["project"]["name"],
             should_use_layout
         )

--- a/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_abc.py
@@ -18,7 +18,8 @@ import unreal  # noqa
 class StaticMeshAlembicLoader(plugin.Loader):
     """Load Unreal StaticMesh from Alembic"""
 
-    product_types = {"model", "staticMesh"}
+    product_base_types = {"model", "staticMesh"}
+    product_types = product_base_types
     label = "Import Alembic Static Mesh"
     representations = {"*"}
     extensions = {"abc"}
@@ -191,7 +192,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
         container_name,
         asset_name,
         representation,
-        product_type,
+        product_base_type,
         project_name,
         layout
     ):
@@ -205,10 +206,11 @@ class StaticMeshAlembicLoader(plugin.Loader):
             "loader": str(self.__class__.__name__),
             "representation": representation["id"],
             "parent": representation["versionId"],
-            "product_type": product_type,
+            "product_base_type": product_base_type,
             # TODO these should be probably removed
             "asset": folder_path,
-            "family": product_type,
+            "product_type": product_base_type,
+            "family": product_base_type,
             "project_name": project_name,
             "layout": layout
         }
@@ -231,6 +233,11 @@ class StaticMeshAlembicLoader(plugin.Loader):
         """
         # Create directory for asset and Ayon container
         folder_path = context["folder"]["path"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
 
         suffix = "_CON"
         path = self.filepath_from_context(context)
@@ -265,14 +272,13 @@ class StaticMeshAlembicLoader(plugin.Loader):
                 container_name, loaded_options
             )
 
-        product_type = context["product"]["productType"]
         self.imprint(
             folder_path,
             asset_dir,
             container_name,
             asset_name,
             context["representation"],
-            product_type,
+            product_base_type,
             context["project"]["name"],
             should_use_layout
         )
@@ -287,7 +293,11 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_type = context["product"]["productType"]
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
         repre_entity = context["representation"]
         # Create directory for asset and Ayon container
         suffix = "_CON"
@@ -324,7 +334,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
             container_name,
             asset_name,
             repre_entity,
-            product_type,
+            product_base_type,
             context["project"]["name"],
             should_use_layout
         )

--- a/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_unreal/plugins/load/load_staticmesh_fbx.py
@@ -16,7 +16,8 @@ import unreal  # noqa
 class StaticMeshFBXLoader(plugin.Loader):
     """Load Unreal StaticMesh from FBX."""
 
-    product_types = {"model", "staticMesh"}
+    product_base_types = {"model", "staticMesh"}
+    product_types = product_base_types
     label = "Import FBX Static Mesh"
     representations = {"*"}
     extensions = {"fbx"}
@@ -99,7 +100,7 @@ class StaticMeshFBXLoader(plugin.Loader):
         container_name,
         asset_name,
         repre_entity,
-        product_type,
+        product_base_type,
         project_name,
         layout
     ):
@@ -113,10 +114,11 @@ class StaticMeshFBXLoader(plugin.Loader):
             "loader": str(self.__class__.__name__),
             "representation": repre_entity["id"],
             "parent": repre_entity["versionId"],
-            "product_type": product_type,
+            "product_base_type": product_base_type,
             # TODO these shold be probably removed
             "asset": folder_path,
-            "family": product_type,
+            "product_type": product_base_type,
+            "family": product_base_type,
             "project_name": project_name,
             "layout": layout
         }
@@ -161,7 +163,12 @@ class StaticMeshFBXLoader(plugin.Loader):
         else:
             asset_dir = self.import_and_containerize(
                  path, asset_dir, container_name
-        )
+            )
+
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
 
         self.imprint(
             folder_path,
@@ -169,7 +176,7 @@ class StaticMeshFBXLoader(plugin.Loader):
             container_name,
             asset_name,
             context["representation"],
-            context["product"]["productType"],
+            product_base_type,
             context["project"]["name"],
             should_use_layout
         )
@@ -185,7 +192,10 @@ class StaticMeshFBXLoader(plugin.Loader):
 
     def update(self, container, context):
         folder_path = context["folder"]["path"]
-        product_type = context["product"]["productType"]
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
         repre_entity = context["representation"]
 
         # Create directory for asset and Ayon container
@@ -218,7 +228,7 @@ class StaticMeshFBXLoader(plugin.Loader):
             container_name,
             asset_name,
             repre_entity,
-            product_type,
+            product_base_type,
             context["project"]["name"],
             should_use_layout
         )

--- a/client/ayon_unreal/plugins/load/load_uasset.py
+++ b/client/ayon_unreal/plugins/load/load_uasset.py
@@ -33,7 +33,8 @@ def parsing_to_absolute_directory(asset_dir):
 class UAssetLoader(plugin.Loader):
     """Load UAsset."""
 
-    product_types = {"uasset"}
+    product_base_types = {"uasset"}
+    product_types = product_base_types
     label = "Load UAsset"
     representations = {"*"}
     extensions = {"uasset"}
@@ -71,6 +72,10 @@ class UAssetLoader(plugin.Loader):
 
         # Create directory for asset and Ayon container
         folder_path = context["folder"]["path"]
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
         suffix = "_CON"
         asset_root, asset_name = unreal_pipeline.format_asset_directory(
             context, self.loaded_asset_dir, self.loaded_asset_name
@@ -106,10 +111,11 @@ class UAssetLoader(plugin.Loader):
             "loader": str(self.__class__.__name__),
             "representation": context["representation"]["id"],
             "parent": context["representation"]["versionId"],
-            "product_type": context["product"]["productType"],
+            "product_base_type": product_base_type,
             # TODO these should be probably removed
             "asset": folder_path,
-            "family": context["product"]["productType"],
+            "product_type": product_base_type,
+            "family": product_base_type,
             "project_name": context["project"]["name"]
         }
 
@@ -178,7 +184,8 @@ class UAssetLoader(plugin.Loader):
 class UMapLoader(UAssetLoader):
     """Load Level."""
 
-    product_types = {"uasset"}
+    product_base_types = {"uasset"}
+    product_types = product_base_types
     label = "Load Level"
     representations = {"umap"}
 

--- a/client/ayon_unreal/plugins/load/load_yeticache.py
+++ b/client/ayon_unreal/plugins/load/load_yeticache.py
@@ -11,7 +11,8 @@ import unreal  # noqa
 class YetiLoader(plugin.Loader):
     """Load Yeti Cache"""
 
-    product_types = {"yeticacheUE"}
+    product_base_types = {"yeticacheUE"}
+    product_types = product_base_types
     label = "Import Yeti"
     representations = {"*"}
     extensions = {"abc"}
@@ -95,6 +96,10 @@ class YetiLoader(plugin.Loader):
 
         # Create directory for asset and Ayon container
         folder_path = context["folder"]["path"]
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
         suffix = "_CON"
         path = self.filepath_from_context(context)
         asset_root, asset_name = unreal_pipeline.format_asset_directory(
@@ -139,10 +144,11 @@ class YetiLoader(plugin.Loader):
             "loader": str(self.__class__.__name__),
             "representation": context["representation"]["id"],
             "parent": context["representation"]["versionId"],
-            "product_type": context["product"]["productType"],
+            "product_base_type": product_base_type,
             # TODO these shold be probably removed
             "asset": folder_path,
-            "family": context["product"]["productType"],
+            "product_type": product_base_type,
+            "family": product_base_type,
             "project_name": context["project"]["name"],
             "layout": should_use_layout
         }

--- a/client/ayon_unreal/plugins/publish/collect_render_files.py
+++ b/client/ayon_unreal/plugins/publish/collect_render_files.py
@@ -57,7 +57,9 @@ class CollectRenderFiles(pyblish.api.InstancePlugin):
                 seq = s.get('sequence')
                 seq_name = seq.get_name()
 
-                product_type = "render"
+                product_base_type = "render"
+                # TODO use product type from instance
+                product_type = product_base_type
                 new_product_name = f"{data.get('productName')}_{seq_name}"
                 new_instance = context.create_instance(
                     new_product_name
@@ -69,9 +71,10 @@ class CollectRenderFiles(pyblish.api.InstancePlugin):
                 new_data["folderPath"] = instance.data["folderPath"]
                 new_data["setMembers"] = seq_name
                 new_data["productName"] = new_product_name
+                new_data["productBaseType"] = product_base_type
                 new_data["productType"] = product_type
-                new_data["family"] = product_type
-                new_data["families"] = [product_type, "review"]
+                new_data["family"] = product_base_type
+                new_data["families"] = [product_base_type, "review"]
                 new_data["parent"] = data.get("parent")
                 new_data["level"] = data.get("level")
                 new_data["output"] = s['output']

--- a/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
+++ b/client/ayon_unreal/plugins/publish/create_farm_render_instances.py
@@ -90,10 +90,13 @@ class CreateFarmRenderInstances(publish.AbstractCollectRender):
                 new_data["folderPath"] = instance.data["folderPath"]
                 new_data["setMembers"] = seq_name
                 new_data["productName"] = new_product_name
-                product_type = "render"
+                product_base_type = "render"
+                # TODO use product type from instance
+                product_type = product_base_type
+                new_data["productBaseType"] = product_base_type
                 new_data["productType"] = product_type
-                new_data["family"] = product_type
-                new_data["families"] = [product_type, "review"]
+                new_data["family"] = product_base_type
+                new_data["families"] = [product_base_type, "review"]
                 new_data["parent"] = data.get("parent")
                 new_data["level"] = data.get("level")
                 new_data["output"] = s['output']
@@ -247,15 +250,27 @@ class CreateFarmRenderInstances(publish.AbstractCollectRender):
             except KeyError:
                 review = inst.data.get("review", False)
 
+            product_base_type = "render"
+            # TODO use product type from instance
+            product_type = product_base_type
+            product_type_kwargs = {
+                "productBaseType": product_base_type,
+                "productType": product_type,
+            }
+            if not hasattr(UnrealRenderInstance, "productBaseType"):
+                product_type_kwargs["productType"] = product_type_kwargs.pop(
+                    "productBaseType"
+                )
+
             new_instance = UnrealRenderInstance(
-                family="render",
+                family=product_base_type,
                 families=["render.farm"],
                 version=version,
                 time="",
                 source=current_file,
                 label=f"{product_name} - {family}",
                 productName=product_name,
-                productType="render",
+                **product_type_kwargs,
                 folderPath=inst.data["folderPath"],
                 task=task_name,
                 attachTo=False,

--- a/client/ayon_unreal/plugins/publish/extract_layout.py
+++ b/client/ayon_unreal/plugins/publish/extract_layout.py
@@ -60,7 +60,18 @@ class ExtractLayout(publish.Extractor):
 
                 parent_id = eal.get_metadata_tag(asset_container, "parent")
                 repre_id = eal.get_metadata_tag(asset_container, "representation")
-                family = eal.get_metadata_tag(asset_container, "family")
+                product_base_type = None
+                for key in (
+                    "product_base_type",
+                    "product_type",
+                    "family",
+                ):
+                    product_base_type = eal.get_metadata_tag(
+                        asset_container, key
+                    )
+                    if product_base_type:
+                        break
+
                 json_element = {}
                 json_element["reference"] = str(repre_id)
                 json_element["representation"] = str(repre_id)
@@ -76,7 +87,8 @@ class ExtractLayout(publish.Extractor):
                 extension = instance_name.split("_")[-1]
                 asset_name = re.match(f'(.+)_{extension}$', instance_name)
                 json_element["version"] = str(parent_id)
-                json_element["product_type"] = family
+                json_element["product_base_type"] = product_base_type
+                json_element["product_type"] = product_base_type
                 json_element["instance_name"] = asset_name.group(1)
                 json_element["asset_name"] = instance_name
                 json_element["extension"] = extension


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
Codebase of Unreal addon is fully using product base type as "pipeline" type. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

Because publish and load still has backwards compatibility for `"asset"` and `"family"` I decided to NOT touch anything that is backwards compatible, or "wrong by design" and just focused on this support. All compatibility changes will be resolved with https://github.com/ynput/ayon-unreal/pull/266 which is stale now.

Product types (aliases) are NOT introduced in this PR. Technical dept of the addon does not allow to easily add them and we really need to finish the conversion as soon as possible. At this moment the changes should support older ayon-core and should be backwards compatible.

## Testing notes:
This is untested PR from my side, please make sure it is fully reviewed.
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Upload the addon to server to use new settings model.
3. Existing workfiles should load up and should be possible to publish.
4. Creating new instances should work as expected.
5. It is possible to load and manage loaded containers with scene manager.